### PR TITLE
Adding informative error messages when betta() fails. See issue #118. 

### DIFF
--- a/R/model_betta.R
+++ b/R/model_betta.R
@@ -145,7 +145,22 @@ betta <- function(chats = NULL, ses, X = NULL,
   }
   if (isTRUE(is.null(X))) { X <- matrix(rep(1,length(chats)),ncol = 1) }
   
-  consider <- !(is.na(chats) | is.na(ses) | apply(is.na(X), 1, sum))
+  consider <- !(is.na(chats) | is.na(ses) | apply(is.na(X), 1, sum) | ses == 0)
+  
+  # check for any standard errors of 0 and give warning 
+  ses_zero <- ses == 0
+  if (sum(ses_zero, na.rm = TRUE) > 0) {
+    warning("At least one of your standard errors is 0. Any observation with 
+            a standard error of 0 has been dropped from the analysis.")
+  }
+  
+  # check for design matrix that isn't full rank and throw error 
+  rank <- qr(X)$rank
+  if (rank < ncol(X)) {
+    stop("Your design matrix is not full rank. We recommend that you 
+         examine your design matrix for linear dependency and remove
+         redundant columns.")
+  }
   
   chats_effective <- chats[consider]
   ses_effective <- ses[consider]

--- a/R/model_betta_random.R
+++ b/R/model_betta_random.R
@@ -90,6 +90,14 @@ betta_random <- function(chats = NULL, ses, X = NULL, groups = NULL, formula = N
   groups_effective <- groups[consider]
   n <- dim(X_effective)[1]; p <- dim(X_effective)[2]; gs <- length(unique(groups_effective))
   
+  # check for design matrix that isn't full rank and throw error 
+  rank <- qr(X)$rank
+  if (rank < ncol(X)) {
+    stop("Your design matrix is not full rank. We recommend that you 
+         examine your design matrix for linear dependency and remove
+         redundant columns.")
+  }
+  
   likelihood <- function(input) {
     ssq_u <- input[1]
     beta <- input[2:(p+1)]

--- a/tests/testthat/test-betta.R
+++ b/tests/testthat/test-betta.R
@@ -70,6 +70,43 @@ test_that("betta isn't stupid", {
     betta_random(ses = dayved,
                  formula = pooleen ~ brybry | sarsh, data = df_uncouth),
     "list")
+  
+  # issue 118 
+  df_issue118 <- df_uncouth
+  df_issue118$dayved[1] <- 0
+  df_issue118$nutmeg <- c(1, 1, 1, 1)
+  df_issue118_v2 <- df_issue118
+  df_issue118_v2$dayved[1] <- NA
+  
+  expect_warning(
+    betta(ses = dayved,
+          formula = pooleen ~ brybry, data = df_issue118),
+    "At least one of your standard errors is 0. Any observation with 
+            a standard error of 0 has been dropped from the analysis."
+  )
+  
+  expect_equal(
+    betta(ses = dayved,
+          formula = pooleen ~ brybry, data = df_issue118),
+    betta(ses = dayved,
+          formula = pooleen ~ brybry, data = df_issue118_v2)
+  )
+  
+  expect_error(
+    betta(ses = dayved,
+          formula = pooleen ~ nutmeg, data = df_issue118_v2),
+    "Your design matrix is not full rank. We recommend that you 
+         examine your design matrix for linear dependency and remove
+         redundant columns."
+  )
+  
+  expect_error(
+    betta_random(ses = dayved,
+          formula = pooleen ~ nutmeg | sarsh, data = df_issue118_v2),
+    "Your design matrix is not full rank. We recommend that you 
+         examine your design matrix for linear dependency and remove
+         redundant columns."
+  )
 
 
 })


### PR DESCRIPTION
Adding informative errors to betta and betta_random, and tests for these errors. When a user inputs data with at least one ses of 0 to betta(), any observations with an ses of 0 are dropped and a warning is given. When a user inputs a continuous variable or variables that create a non full rank matrix to betta() or betta_random(), the function will fail with an informative error message.