### PR TITLE
Addressing issue #89 by adding static html files

### DIFF
--- a/vignettes/breakaway.html
+++ b/vignettes/breakaway.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+
+<meta charset="utf-8" />
+<meta name="generator" content="pandoc" />
+<meta http-equiv="X-UA-Compatible" content="IE=EDGE" />
+
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<meta name="author" content="Amy Willis" />
+
+<meta name="date" content="2021-10-21" />
+
+<title>Getting started with breakaway</title>
+
+<style type="text/css">
+a.anchor-section {margin-left: 10px; visibility: hidden; color: inherit;}
+a.anchor-section::before {content: '#';}
+.hasAnchor:hover a.anchor-section {visibility: visible;}
+</style>
+<script>// Anchor sections v1.0 written by Atsushi Yasumoto on Oct 3rd, 2020.
+document.addEventListener('DOMContentLoaded', function() {
+  // Do nothing if AnchorJS is used
+  if (typeof window.anchors === 'object' && anchors.hasOwnProperty('hasAnchorJSLink')) {
+    return;
+  }
+
+  const h = document.querySelectorAll('h1, h2, h3, h4, h5, h6');
+
+  // Do nothing if sections are already anchored
+  if (Array.from(h).some(x => x.classList.contains('hasAnchor'))) {
+    return null;
+  }
+
+  // Use section id when pandoc runs with --section-divs
+  const section_id = function(x) {
+    return ((x.classList.contains('section') || (x.tagName === 'SECTION'))
+            ? x.id : '');
+  };
+
+  // Add anchors
+  h.forEach(function(x) {
+    const id = x.id || section_id(x.parentElement);
+    if (id === '') {
+      return null;
+    }
+    let anchor = document.createElement('a');
+    anchor.href = '#' + id;
+    anchor.classList = ['anchor-section'];
+    x.classList.add('hasAnchor');
+    x.appendChild(anchor);
+  });
+});
+</script>
+
+<style type="text/css">
+  code{white-space: pre-wrap;}
+  span.smallcaps{font-variant: small-caps;}
+  span.underline{text-decoration: underline;}
+  div.column{display: inline-block; vertical-align: top; width: 50%;}
+  div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+  ul.task-list{list-style: none;}
+    </style>
+
+
+<style type="text/css">code{white-space: pre;}</style>
+<style type="text/css" data-origin="pandoc">
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; left: -4em; }
+pre.numberSource a.sourceLine::before
+  { content: attr(data-line-number);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+
+</style>
+<script>
+// apply pandoc div.sourceCode style to pre.sourceCode instead
+(function() {
+  var sheets = document.styleSheets;
+  for (var i = 0; i < sheets.length; i++) {
+    if (sheets[i].ownerNode.dataset["origin"] !== "pandoc") continue;
+    try { var rules = sheets[i].cssRules; } catch (e) { continue; }
+    for (var j = 0; j < rules.length; j++) {
+      var rule = rules[j];
+      // check if there is a div.sourceCode rule
+      if (rule.type !== rule.STYLE_RULE || rule.selectorText !== "div.sourceCode") continue;
+      var style = rule.style.cssText;
+      // check if color or background-color is set
+      if (rule.style.color === '' && rule.style.backgroundColor === '') continue;
+      // replace div.sourceCode by a pre.sourceCode rule
+      sheets[i].deleteRule(j);
+      sheets[i].insertRule('pre.sourceCode{' + style + '}', j);
+    }
+  }
+})();
+</script>
+
+
+
+<style type="text/css">body {
+background-color: #fff;
+margin: 1em auto;
+max-width: 700px;
+overflow: visible;
+padding-left: 2em;
+padding-right: 2em;
+font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+font-size: 14px;
+line-height: 1.35;
+}
+#TOC {
+clear: both;
+margin: 0 0 10px 10px;
+padding: 4px;
+width: 400px;
+border: 1px solid #CCCCCC;
+border-radius: 5px;
+background-color: #f6f6f6;
+font-size: 13px;
+line-height: 1.3;
+}
+#TOC .toctitle {
+font-weight: bold;
+font-size: 15px;
+margin-left: 5px;
+}
+#TOC ul {
+padding-left: 40px;
+margin-left: -1.5em;
+margin-top: 5px;
+margin-bottom: 5px;
+}
+#TOC ul ul {
+margin-left: -2em;
+}
+#TOC li {
+line-height: 16px;
+}
+table {
+margin: 1em auto;
+border-width: 1px;
+border-color: #DDDDDD;
+border-style: outset;
+border-collapse: collapse;
+}
+table th {
+border-width: 2px;
+padding: 5px;
+border-style: inset;
+}
+table td {
+border-width: 1px;
+border-style: inset;
+line-height: 18px;
+padding: 5px 5px;
+}
+table, table th, table td {
+border-left-style: none;
+border-right-style: none;
+}
+table thead, table tr.even {
+background-color: #f7f7f7;
+}
+p {
+margin: 0.5em 0;
+}
+blockquote {
+background-color: #f6f6f6;
+padding: 0.25em 0.75em;
+}
+hr {
+border-style: solid;
+border: none;
+border-top: 1px solid #777;
+margin: 28px 0;
+}
+dl {
+margin-left: 0;
+}
+dl dd {
+margin-bottom: 13px;
+margin-left: 13px;
+}
+dl dt {
+font-weight: bold;
+}
+ul {
+margin-top: 0;
+}
+ul li {
+list-style: circle outside;
+}
+ul ul {
+margin-bottom: 0;
+}
+pre, code {
+background-color: #f7f7f7;
+border-radius: 3px;
+color: #333;
+white-space: pre-wrap; 
+}
+pre {
+border-radius: 3px;
+margin: 5px 0px 10px 0px;
+padding: 10px;
+}
+pre:not([class]) {
+background-color: #f7f7f7;
+}
+code {
+font-family: Consolas, Monaco, 'Courier New', monospace;
+font-size: 85%;
+}
+p > code, li > code {
+padding: 2px 0px;
+}
+div.figure {
+text-align: center;
+}
+img {
+background-color: #FFFFFF;
+padding: 2px;
+border: 1px solid #DDDDDD;
+border-radius: 3px;
+border: 1px solid #CCCCCC;
+margin: 0 5px;
+}
+h1 {
+margin-top: 0;
+font-size: 35px;
+line-height: 40px;
+}
+h2 {
+border-bottom: 4px solid #f7f7f7;
+padding-top: 10px;
+padding-bottom: 2px;
+font-size: 145%;
+}
+h3 {
+border-bottom: 2px solid #f7f7f7;
+padding-top: 10px;
+font-size: 120%;
+}
+h4 {
+border-bottom: 1px solid #f7f7f7;
+margin-left: 8px;
+font-size: 105%;
+}
+h5, h6 {
+border-bottom: 1px solid #ccc;
+font-size: 105%;
+}
+a {
+color: #0033dd;
+text-decoration: none;
+}
+a:hover {
+color: #6666ff; }
+a:visited {
+color: #800080; }
+a:visited:hover {
+color: #BB00BB; }
+a[href^="http:"] {
+text-decoration: underline; }
+a[href^="https:"] {
+text-decoration: underline; }
+
+code > span.kw { color: #555; font-weight: bold; } 
+code > span.dt { color: #902000; } 
+code > span.dv { color: #40a070; } 
+code > span.bn { color: #d14; } 
+code > span.fl { color: #d14; } 
+code > span.ch { color: #d14; } 
+code > span.st { color: #d14; } 
+code > span.co { color: #888888; font-style: italic; } 
+code > span.ot { color: #007020; } 
+code > span.al { color: #ff0000; font-weight: bold; } 
+code > span.fu { color: #900; font-weight: bold; } 
+code > span.er { color: #a61717; background-color: #e3d2d2; } 
+</style>
+
+
+
+
+</head>
+
+<body>
+
+
+
+
+<h1 class="title toc-ignore">Getting started with breakaway</h1>
+<h4 class="author">Amy Willis</h4>
+<h4 class="date">2021-10-21</h4>
+
+
+
+<p><code>breakaway</code> is a package for species richness estimation and modelling. As the package has grown and users have requested more functionality, it contains some basic generalisations of the statistical philosophy that underpins <code>breakaway</code> to the general alpha diversity case. Because of the flexibility of the modelling strategies, most users of breakaway are microbial ecologists with very large OTU tables, however, nothing should exclude a macroecologist from using the same tools. If you have a macroecology dataset and want to use this package, I would love to hear from you so please feel free to contact me (email or via Github’s Issues/Projects infrastructure).</p>
+<div id="vignette-info" class="section level2">
+<h2>Vignette Info</h2>
+<p>This vignette will lead you through the most basic way to use <code>breakaway</code>. For a more in depth discussion of how and why estimating species richness is possible, check out the <em>Introduction to diversity estimation</em> vignette.</p>
+</div>
+<div id="diving-in" class="section level2">
+<h2>Diving in!</h2>
+<p>Download the latest version of the package from github.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="kw">library</span>(breakaway)</a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw">data</span>(toy_otu_table)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="co">## For historical reasons we're going to rename it:</span></a>
+<a class="sourceLine" id="cb1-4" data-line-number="4">otu_data &lt;-<span class="st"> </span>toy_otu_table</a></code></pre></div>
+</div>
+<div id="creating-frequency-tables" class="section level2">
+<h2>Creating frequency tables</h2>
+<p>We’re now going to “collapse” the otu_data’s columns (samples) into frequency tables. Frequency tables…</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1">frequencytablelist &lt;-<span class="st"> </span><span class="kw">build_frequency_count_tables</span>(otu_data)</a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="kw">head</span>(frequencytablelist[[<span class="dv">63</span>]])</a></code></pre></div>
+<pre><code>##   index frequency
+## 1     1        35
+## 2     2        22
+## 3     3        15
+## 4     4        17
+## 5     5        11
+## 6     6        10</code></pre>
+<p>Interpretation: In this sample, there were 35 different species observed only once (singletons), 22 different species observed only twice, …, 1 species observed 2922 times.</p>
+</div>
+<div id="estimating-species-richness" class="section level2">
+<h2>Estimating species richness</h2>
+<p>Let’s run breakaway on the first frequency count table</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1"><span class="kw">breakaway</span>(frequencytablelist[[<span class="dv">1</span>]])</a></code></pre></div>
+<pre><code>## Estimate of richness from method breakaway:
+##   Estimate is 359
+##  with standard error 325.81
+##   Confidence interval: (258, 18180)</code></pre>
+<p>You should get some output to screen, including your estimate &amp; s.e. You can also investigate a plot of the fits to the ratios as follows:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1"><span class="kw">plot</span>(<span class="kw">breakaway</span>(frequencytablelist[[<span class="dv">1</span>]]))</a></code></pre></div>
+<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASAAAAEgCAYAAAAUg66AAAAEGWlDQ1BrQ0dDb2xvclNwYWNlR2VuZXJpY1JHQgAAOI2NVV1oHFUUPrtzZyMkzlNsNIV0qD8NJQ2TVjShtLp/3d02bpZJNtoi6GT27s6Yyc44M7v9oU9FUHwx6psUxL+3gCAo9Q/bPrQvlQol2tQgKD60+INQ6Ium65k7M5lpurHeZe58853vnnvuuWfvBei5qliWkRQBFpquLRcy4nOHj4g9K5CEh6AXBqFXUR0rXalMAjZPC3e1W99Dwntf2dXd/p+tt0YdFSBxH2Kz5qgLiI8B8KdVy3YBevqRHz/qWh72Yui3MUDEL3q44WPXw3M+fo1pZuQs4tOIBVVTaoiXEI/MxfhGDPsxsNZfoE1q66ro5aJim3XdoLFw72H+n23BaIXzbcOnz5mfPoTvYVz7KzUl5+FRxEuqkp9G/Ajia219thzg25abkRE/BpDc3pqvphHvRFys2weqvp+krbWKIX7nhDbzLOItiM8358pTwdirqpPFnMF2xLc1WvLyOwTAibpbmvHHcvttU57y5+XqNZrLe3lE/Pq8eUj2fXKfOe3pfOjzhJYtB/yll5SDFcSDiH+hRkH25+L+sdxKEAMZahrlSX8ukqMOWy/jXW2m6M9LDBc31B9LFuv6gVKg/0Szi3KAr1kGq1GMjU/aLbnq6/lRxc4XfJ98hTargX++DbMJBSiYMIe9Ck1YAxFkKEAG3xbYaKmDDgYyFK0UGYpfoWYXG+fAPPI6tJnNwb7ClP7IyF+D+bjOtCpkhz6CFrIa/I6sFtNl8auFXGMTP34sNwI/JhkgEtmDz14ySfaRcTIBInmKPE32kxyyE2Tv+thKbEVePDfW/byMM1Kmm0XdObS7oGD/MypMXFPXrCwOtoYjyyn7BV29/MZfsVzpLDdRtuIZnbpXzvlf+ev8MvYr/Gqk4H/kV/G3csdazLuyTMPsbFhzd1UabQbjFvDRmcWJxR3zcfHkVw9GfpbJmeev9F08WW8uDkaslwX6avlWGU6NRKz0g/SHtCy9J30o/ca9zX3Kfc19zn3BXQKRO8ud477hLnAfc1/G9mrzGlrfexZ5GLdn6ZZrrEohI2wVHhZywjbhUWEy8icMCGNCUdiBlq3r+xafL549HQ5jH+an+1y+LlYBifuxAvRN/lVVVOlwlCkdVm9NOL5BE4wkQ2SMlDZU97hX86EilU/lUmkQUztTE6mx1EEPh7OmdqBtAvv8HdWpbrJS6tJj3n0CWdM6busNzRV3S9KTYhqvNiqWmuroiKgYhshMjmhTh9ptWhsF7970j/SbMrsPE1suR5z7DMC+P/Hs+y7ijrQAlhyAgccjbhjPygfeBTjzhNqy28EdkUh8C+DU9+z2v/oyeH791OncxHOs5y2AtTc7nb/f73TWPkD/qwBnjX8BoJ98VQNcC+8AAAA4ZVhJZk1NACoAAAAIAAGHaQAEAAAAAQAAABoAAAAAAAKgAgAEAAAAAQAAASCgAwAEAAAAAQAAASAAAAAAq0AljQAAQABJREFUeAHtXQdgFUUTnpeEJBB6b9KkqoBSBaTYEERROvz8CoqiYsPfBopYUH8RadIs/EpRQYoiIApiRRELRXrvvUkIJSHl/v0W97h3uffyanL33oyGd7e3N7v77d3c7OzujEsTREyMACPACOQBAjF5UCYXyQgwAoyARIAFED8IjAAjkGcIsADKM+i5YEaAEWABxM8AI8AI5BkCLIDyDHoumBFgBFgA8TPACDACeYaAbQXQsWPH6IEHHnD7e+ihh+iZZ56h0aNH0969e91Ae/755+ndd991S/P15Pjx475mzTHf0aNHaeDAgXTddddR165dc8wfaAZjnVetWiVx2rVrV6DsbHffF198IduUlZXltW5mvK2wMGKlmFmlqWv+/vpaV3/5esofzLPuiWc40sePH0+PPfaYJesTJ07Qo48+SoR1QHakbdu2YX2SVqhQIa1ixYr6X+HChWV6TEyM9s477+hVr1KlitalSxf93NcD8fBoJUuW9DV7jvk6dOigxcXFae3atdOeeuqpHPMHksFc59mzZ0tMVqxYEQg7W97z3HPPyTalp6d7rZ8ZbzMWZqzAzCrNayE5XPS1rjmw8flyoM+6zwWEKOOtt96qJSUlZeMmhL9Wv359+Z7EWYonGyU+8sgj9Prrr7vVaMOGDdSpUyfCtfbt21OlSpXcrvtz8sMPP9CpU6f8ucVr3t9++41uueUWWrhwodd8wVw01/nmm2+mv/76i2rUqBEMW0fea8Y7OTnZDQszVmikVZojG+/ASkPzufHGG2njxo306aefkm2HYN6wvfLKK+nxxx+njIwM+vnnn71lpUOHDtE333xDeFDPnj3rlhfq++nTp2Xa7t276e+//3a7bj65cOECrV69mr766itCfiOdO3dOpoFfqVKl5LG5PJX/wIEDsqwzZ87Q999/TykpKeqS/D18+LB8Sb799lvat2+f2zWrOufLl4+EZkixsbFueb3V15hxy5Yt9OWXX8q2nT9/3njJ67G3euJG1U4cY8i8ePHibLjhGkh8JgnDpz///FP268VUz/96wtuIhRVWVmnGUk6ePCn7RGiThDKsyN+6pqamynajv82Ej99u8SwZh5o54WrmsX//foLJwkzga/64ZmZmypf/66+/luWa71HnOT0TeC7Rv/6QEj6bN2+mzz//nDp37mz/IdjgwYOzqXBImDRpklTR33vvPXndrJaKh0e79957NZfLpYkXU+bFcE7lx0133HGHTBcgyl9hX5K8rP5ZsmSJhjKQV/G76aabNNERMruQ5m68kG/GjBlWrLTq1atrDz/8sFanTh15T+nSpTUMNQ4ePKhBbcW9GGKqegltTxMPseRlVWfzsAMZc6ov8ggBqaENxjYVKVJEQ1u8kS/1xP1o34ABAzTUX7UFv71795btVWUIwaSVLVtWb3fNmjW1Hj16yHNPQzBPeBuxsMLKKg31EMJaGzRokMQd2OO5wXB/2rRpqpryN5C6CqGmJSQkyD53YyZO2rZtqwnNVSb7iqv5WTefgxnaA6yN78/KlSu12rVry3T1DMNUIASeLB//+PpMlClTRkM/eSPjEEwNuwoUKCCfTXWf7W1ARgBVpfEyYgyJh2Tt2rUy2dwJQkPSxNdQ2okgjMSXT+vbt68EHzYAkNBWtAcffFCORQEQwLeiPXv2yIexRYsWmvgyyJdHfEE0CI5GjRpp4quipaWlaeCBB61///7yGGlWBAEUHx+vdezYUQqp6dOny2ywYSUmJmrgjbps2rRJClE8SFOnTpV5rOpsfOmQyZf6It/LL78s2y40Oingtm7dqgnjuRy3C60MWSzJl3riRggg2MPw0v/000+a+FJrffr0kX0wZ84cyXv79u1asWLFNNhy8CKgXGFklXnQbk8CyBPeRiyssLJKQ0WAhXphgZ/QhjUxxJdpqDso0LriXghU2BohGBRB4EAQvPbaazLJV1zNz7r5HMzMAkhoH1qJEiW0evXqSRsYrqNdFSpU0MSQSFXJ52cC2Dz99NP6fVYHSgAp4QN8J06c6JbV9gIIgua+++6Tf/369dPuvPNOrVy5cvLBwNdVkbET0LEQTtAyjCSGbFqtWrW0q666Sk9+4okn5EuiJ1gcQEhBsChtR2WB4ACo6mVCOvIJy7/KYvkLAYSvq1HgQYjBaG00rONmlIky8FIqMtfZ+NIhj6/1hUDGSyHUd8VaCthZs2ZpQnXX04wH/tQTAggPPT4AiiBk1IuONDzE+fPnlx8IlQe/jRs3lvk8CSCV14y3GQszVrjPnCbsRrIOzZo1U2zlL8oGPtdff708D6au+Kig3QsWLNDLeOutt6TGhT72B1fjsw5m5nOkmQXQkCFDZPnQ4Iw0ZswYmf7jjz/K5ECeCSM/4zEEEPoH73DRokXlM3/55ZdrwFuR7Y3QmFpW41ghVEhoHdSyZUvq2bOnNESLTs1GMFKLBpIAwO2a+NpIA/GECRNIdBAJLcTtuqeTdevWkfhykJiNc8sivtryHAZg8fVyu5bTiRCEJNRRPZtQ+2nEiBGy3jt37pTjdIzDYYsAwY7gK/laX/FVJiFESQhEEqq4/ANm3bp181iUv/VEO4WA0fkJ1Z1gp1H2EGAHmx7sZkaCIf+PP/4wJoXtGDjD9oVnS7yQbuUIDYGEli3TgqkrJgrw/Hz88cd02223SX5ieEcqHQmh6n/J3PQP7GtCuya8GzAAK4K9CYQ2tmrVigJ5JhQvq1+hqRJsVN999x2tX7+e7r77brm8QpgnZHbbCyChxWSbBbNqqDENDQbhgTITHnTxtZHGZ/F1M1+2PAc/oTVluyaGDiSGGATjmr8ktLhst8BYLrQ6Eqq+FI5Cg5APBTJCoPpKvtYXQmfp0qU0cuRImj9/vpyVgJC+//77aezYsR4FtD/1BEZmghBT7YGhtGrVquYsBEGVW6SelzVr1pBY/pGtWGGfkh+AYOqKNovhJ40aNUpOOuDDipdeTOHr5fmDq36ThwOFr7qMNuIDPnnyZJWk/15xxRUEQQEK9JnQmZkO8H5goqVu3bp0zTXXyNnhmTNnypkwMbIh2wsgU3t8Or3ssstkPjEUy5Yflns83L4KHzAAPyteR44ckTM2ANdfwsNgJMzOiOElQej88ssvJGxLUgDgCzVu3Dj9hTXe4+nYn/q2adOG8AcNS9gEZFliGEgNGzYkPCBmCmU9wRsPPzQ+Mwm7gTkpbOdKsxVDfHrhhRc8lhNsXe+55x4S9h6aN28eQUuFcBb2MVleMLhCuJk1ZPPzijZC6EGrNGreVo3195mw4qHSxBBMCh91jmdr+fLlcha7efPmzpyGV43x9AuBgIYLW4ZbFnQSvvSQxIrwxccUqHEaVF1Tv8IeIb9WmD40EtYxgIz8jNf9OcYyAUz7Ym0TOkYND8XYXLKB1qYopzr7Wl+8EFC78bWEei5mZPTV5NDCrMifelrdb05DXTEswDDISFgWEAqywsqcJmaGqGDBgoQhkZEwLEP9oLmAgq2rsH9IvD/77DMStirq1auXxB28g8EVSzCUFgdeIDV0v3h2se5Y7oHpbyN9+OGHhHr9/vvvMjmQZ8LIL6djCF0xoSKHvBju4eGzJamV0FazYFYVNhviYLSFIRr3g5dYX6IJu4Kc4Vm2bJnOYtiwYdIIN3z4cE18HfR04wFm0GBEgwFbqMmaUMXldL54aDWxlkGDcVuR2Siq0o2/MEJjZshImPFCfYXw0cR4XROamiYeDllf8cJo4sHQs5vrbDa8+lpfsVhSth1GWUzR/vrrr3KKHPUwYqQXLA78qSeM0JjdMhMwwiwKCLNNwFXYgWSZ6Cux5UZf6hCsEdqMFcq0SkP/i5dHE/YZDYZaYCFsYdJIrFaYB1tXlI0+FRqLLEu89EiS5A+u5mddbP2R/LCMAP34/vvvS+M5jPvq/YHhF0sdMH2O9qO8KVOmSMOwsY98fSYwgysEqKq+5a+aBbO6+J///EfWOWIFEISCWEGtQUjgwcJLLL5gmhiPuuEh1H8NlnnkwXoVTyS+0hpmSZAPf8KWJGebMNtgpEAFEHjgwRHalF6GUPk1sRhRE6u9ZR1VOeY6mwUQ8vlaXzy8WBKg2lW+fHlt7ty5qijLX1/r6YsAQgEQOkLtl7ORqEfTpk21F198UdYpWAFkxgrlWaUJDVgTdi/5oUEd8LyIyQ4pMHCPomDqCh7C+C6fSeNMrOLtK65mAYQpdghOfDhQdwgaCFF86JQAQhlYRoAZPWM+zCwL7UlVQf768kxAkPmzDsitAHEiRiNySYALF0SlI5YwtMLYF8ZnqKqeCIZkXMcMjTcS60gI43WoraIjvWUN+BrUacwciSlsrzx8qbMv9cVQAyuV0X4r47inSvhaT0/3m9Mx24m6+FMHMw9P51ZYWaXhfrEOiMSiVSpevLgndnJmNlx1DRRXbEPBSm4ro76xIRjqwxaK2U9Pz3Cgz4SxHF+OI14A+QIC52EEGIG8QcCRe8HyBioulRFgBEKNAAugUCPK/BgBRsBnBFgA+QwVZ2QEGIFQI8ACKNSIMj9GgBHwGQEWQD5DxRkZAUYg1AiwAAo1osyPEWAEfEaABZDPUHFGRoARCDUCLIBCjSjzYwQYAZ8RsOVueLH8Xq6INbcCi7Y9rdw05+Vz+yEQSP+hv7EqmSkyEbClAILDbDgsUm41AD0eXuxmxy5x7GYOhsALQk7tOA+GF/yo4CUJBS9/nKR5qzOc9aN9Rkdg3vJ7uwZecPeAv2AIW2KAFbwU+MMLTurhnJ8pMhGwpQAC1PB4KHbc6qjDHQX2YIld6UG/WOAF1wTgFSzBbw2cLoWCF/bxeNt/5Gtd0Tbh7pXgSCtYAi8IjWAFLAQisML+Nn94icACwTaB77cxAsF91mzcMK4aI8AI2B8BFkD27yOuISMQsQiwAIrYruWGMQL2R4AFkP37iGvICEQsAiyAIrZruWGMgP0RsO0smP2hC7yGmpiSTl/wBaX/9CO5kpIovkcvirsye9ifwEvgOxkBZyDAGlAe9FP6t9/Qhc/mkHb8GGXt2U2po9+iLLHEgIkRiDYEWADlQY9nrvzTvVSxRiZz3cXom+4X+IwRiGwEWADlQf+6LCK2WqXlQdW4SEYgVxFgAZSrcF8sLL5zV3IZQjPHtWxNcXXr5UFNuEhGIG8RYCN0HuAfU7QYFRj2X8rcvk0aoWMrVc6DWnCRjEDeI8ACKI/6wCXij8XVuSKPSudiGQF7IMBDMHv0A9eCEYhKBFgARWW3c6MZAXsgwALIHv3AtWAEohIBFkBR2e3caEbAHgiwALJHP3AtGIGoRIAFUFR2OzeaEbAHAiyA7NEPXAtGICoRYAEUld3OjWYE7IEACyB79APXghGISgRsuRIaIVwQ1QFRIhQhlA7ozJkzljHDVD5ffsEL4WaM/H25zyoP+CDKRih4IXJEKPigTmhjqHghnI4/oXSscEKfgk6fPu0XL7SFKXIRsKUAwsOeJBx1FStWTEceL/mxY8eoYMGClJiYqKcHcgBeEGRFihQJ5Ha3e0IdlsfYZreC/DhB2yDAQ8ULYXT8CaVjVVUI1xMnTsggg/7wQsgjpshFwLa9i2B/xiiono4D6RrFS/0GwkPdAx7qT6UF+hsqPqr8ULQPvEJRL1WXUPBS7eNf5yPANiDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAcciwALIsV3HFWcEnI8ACyDn9yG3gBFwLAIsgBzbdVxxRsD5CLAAcn4fcgsYAccikGsC6O+//6alS5fSoUOHHAsWV5wRYARCi0CuCKAvvviCHnvsMdq1axe9/PLLNGbMmNC2grn5hYCWlkqapvl1jy+ZtYwM0tLTfcnKeRgBiUBcuHHIzMyk6dOn04gRI6hq1arUu3dv6t69O/Xp04eKFSsW7uKZvwGBrORkSps0njI3bSRXkaKU0O9+iqt/tSFH4IcX5s8j/JHo73w33Ejxve8mV0yufN8CrzTfmecIhF0AxcbG0tSpUykpKUk2NjU1lc6cOSOe00y3xm/ZskU/x3CtUKFClG74mmZlZcnruM+Yrt/kxwF44S9YPigSmkSoeIWSD+pmbl/61A8oSwgfkJZ8ilInjKP4N0aQS2DtiYB3htBsXC6XpyyUuW4tZcydrV9PX/oNaWXLUWybG/Q08ADlxEu/4Z+DcGhqxjIuXLgg+y8xMdGYzMe5hEDYBRDaoYQPXrCxY8dSu3btqGTJknoT8ZB17NhRP7/66qupQ4cOdPz4cT1NHaSkpBD+QkFpaWmhYCNfqlDxsmpzoJU080oSQt5NJxFDsVMb1lNm9Rpeizh//rzX6/Fr11CCKcd5wTf1qnqmVKJkoYX5Q2Yh6s+9OeXFh65Zs2Y0f/58qlmzZk7Z+XoYEMgVAYR64wV95ZVXpMbw/PPPuzUFX9ePPvpIT/vrr7+oYMGCVLx4cT0NwuvUqVMyPT4+Xk8P5AC8zp07J3kFcr/xHrxQ0PJQ32AJghWaX7AEgQFN0zzEzahajbR1f11iny8fFa5VWwzHilxKMx2BVz6RLy7O86OSVbsOZX7/ndudCTVqUgFD/0HzOX36tGwf+PlK3sr1lYenfHiejJq3p3ycHj4EPD9VISwTL/uzzz5LFSpUoKefflq+sGb2jRs31pMOHz4sBVVCwqXvqhqy4YE0pus3+XEAXhCIwfJBkTHCzgEBFApeZ8+eDQkfDCtA5jrlu+deSn17DGXt3kWUPz8l3itsQKVLy7ye/gEvCAyvQv/a5pQmJhjSF3+FMSnFNWtOCe1uJZfARRFwAoGPV17qhn9+1X2m5KBPgfXgwYMlnyFDhtC9995LCxYsoB49elCrVq10/p999hnt2LGDBg4cSAMGDJCTKe+++y7t2bOHbrzxRrrvvvvcPj5r1qyhCRMmyOtXXHEFPfPMM1S+fHmdHx+4I+CmkbtfCt3Ziy++SLVq1aJBgwZZCp/QlcScvCEQU6IkFXj5VSowehwlvT2R4po09Zbdr2sJvXpT0oR3KWn8O5T44MNuwscvRrmUGR+y+vXry9Lq1q0rP4748I0aNcqtBi+99JI8x0dr8uTJdPPNNxO0QpgMxo8fLydTlJ3qu+++k0M62Di7detGv/32G9WrV48OHjzoxpNPDAgI8MJKGzdu1K677jr517JlS039iWGWx3LFmFwTU/du14UKr4mO1IQ25ZYeyAl4ifF/ILdmu+fYsWMh43XixIls/ANJEEMdTay3CuTWbPeAl9AWs6X7myA0Kdl//vK65557/C3K5/w7d+7EWgRNDMPkPUID0oR2pql+WL16tSa0W1lvIXRkXjF7q/NfuXKlTPv+++9l2jXXXKN16tRJv44DpD388MNuaXxyCYGwD8Hq1KlDy5YtM4g8PmQE7IkAJkdgd5w1axY9+OCDNG3aNLrllluoXLly0qaGWrdv316vvBAuVKpUKVq1apXUfGC7RF5o+oowPP/zzz/VKf+aEMiVIZipTD5lBGyJAIZld911l5wQwZDrk08+ob59+7rVtXLlyvo5Jk+KFi0ql5XAwI7JDUxGwG6l/jBk69Kli34PH7gjEHYNyL04PmME7IOAWtskBgR6pSBw3nrrLakFwQBvXB6CTLDzXHvttTL/3r17adu2bdSgQQOpCRUuXFganF9//XWd35IlS6QRX0/gAzcEWANyg4NPogkBtcxD2HL09UmYuWrSpAn95z//oZ49e2abScSw7Pfff6cjR47QCy+8QNWrV9dnzR566CG56h/riqBB/fTTT3THHXdYrmeLJpy9tZU1IG/o8LWIRgAaC+w+2B4EgTNy5EjZXmH4ljYg8/ALF7FcpE2bNnK4ddVVV9GXX35J4APCbC9mwLp27SrXTZUpU0YuO8GMGJM1AiyArHHh1ChB4KuvvpIr6wsUKKC3GPYbTM1DEzIT1gv973//kxoTDNBGyi/WVmFqfvTo0VJDqlixovEyH1sg4JcAwlgZ414xtU5FxOpZbJkwdpwFf05iBGyPgFp9Dm8NeL7feOMNuXDWU8WxkNIsfIx5sXCThY8REc/HPtmAMEbG9CNUzSpVqsh9Wi1atJDnUEP79+8vXW14LoavMAL2R2D27Nl0ww03UNOmTeUKZ2ONYbCG0PFnFbfxfj62RsCrAMJyc4yP7777bjn2XbhwoRQ02MZw8uRJub7nySeflNsmMBOApe2h2ihqXV1OZQTChwC2TWCLBqbfzVtAsK3l6NGjhA8vU+gQ8CiAsKYB+2IgfDZs2CA3krZu3VpqQFAxsdERO4lhsHv//fdp8+bN0mUD9sYwMQJORYDdcuRuz3m0AeELsHz58mxfAk/Vg8Uf6x8w/cjECDACjIAvCHjUgHCzWQ31xBCb8xRh6TkTI8AIMAK+IOBVABkZYIm62KRnTJLHcE0ANwVMjAAjwAj4i4DPAkjsHJbuC3788UdZBgxyt99+u/STIna4+1su52cEGAFGwN1Dpzc8hMsB+te//iX9oWDJORZqQSMSLgukMydv9/I1RoARYASsEPBohDZnxvqHYcOG0datW+mdd96Rbgs++OADql27tjkrnzMCjAAj4BMCPg/Bfv31V4L/kz/++IPmzp0r3VFi7Q88yGHKnokRYAQYAX8R8FkA3XrrrXTllVfSunXrqHPnztJdATQhBBp89NFH/S2X8zMCjAAj4N0GdODAAR2i9957j7BUXbkwwAUsUoQXuBo1LoV1gbGaiRFgBBgBXxDwqAFh4+mdd95JiBgA3yeeXApgb9jjjz8uIwoI388yAqovBXMeRoARYAQ8GqGx+W7FihUyEgBsPQjchjAklSpVossuu0zGeML2C/zBPoT8sAcZfeYyvIwAI8AIeEPAowaEm7Cq+YEHHpDB29q2bSu3ZsALHHYMw1scjNHYO4NAg7ANsfDxBjVfYwTcEcDG7RkzZsh9lvCiCL/SRvr4449tubkboyOYZIyubI319ufYqwBSjOBoGzvdFy1aJAOuATj8wTXlpEmTpCPvcEawVPXgX0YgtxEQcaAobeYndH7km3Rh8dekhWjGF7ZTxCVD4EN8xCFs4N4V6+oUIYinOby2upaXv5j1hmISCgHkcQiGBg4fPpzglhIbTbHfCx7fQKEIQywZ8T+MgI0RwAt2ftQIytq2VdYyc+1fpP19khJ6/iuoWmPDtogvRnBlI2KG6bwQDgijCHifKFGihExHHeD4HpM/Kg0XENd+3759VLVqVbdw3siPiSCs24OpBJSeni7fX/ziOvZ4wgmbCpEN9zoI5Q0ngyAIPex0gNnFqFggH1z0oMxQkVcNCD5u0XgQ4h0hljYTIxAtCGSJWWAlfFSb07//Th0G/Iu1dCJwJGFHgZG6d+8uPSka4+hh9wGUgMsvv5zefPNNmR3+iho2bEhDhw4lxN3DOQhCCRE7MGEE1zmYRILAQYTW66+/Xq7jw/UnnniCxo0bJ+/BP5hoUhFhMdKBk0FoOJjdFkEbZb558+bJiB9wtwPeoSKvGpCqCIzPkJCw9ZjjjaMiUCUh0ZkYgUhCwJU/MVtzXP+MArJd8CMBuwkw3LLyNgE3xxBQEB4grL+DoMGSmGrVqknbK3YgQBjB+T28lWKyCAQNCouFsT4PWhZCCmGCCLR+/XqpGUGRgICDEIIjfgynYIdCBA8R5VcOBaHl4D2H72vwQllYcvPtt99Kx4RTpkzR+UrmQfzjVQBhXAofPwAMDdq0aZOuthnLNKqGxnQ+ZgScjEBMiZKUr+0tlL5k8cVmiJne+B49g24ShlMYzlgRPvQlS5bUL0HIgCpUqCD3X0LgQCPCHxwBIuwPvJaCsE4PhGsgDKPmzJkjFw5DeIEHqFWrVtLgDd/uEGwQhrgOwzKGbtB+QPAOCe0J/GB+adSokUy/7bbb5Ky3PAnyH68CCCrY1KlTZRGQrFDDVAiSIMvl2xkBRyCQ0Ptuiq1bn7IOHqDYOldQbOUqQde7efPm8mOOYRg0EkUQStBOjDsLjFoShBPeSYxMoBmJWPYyDhkmgjALDUIoaaN3CnguhWZjtNtiyQyECoZucMIPr6YgDNcgjBCW2kgQSrAfQVvCzDj+jPUy5vX32KMNCIXB+IwxKIQQwpew8PEXXs4fCQjE1atP8e1uDYnwAR7QgJ566in697//LYUD0jDJgxcfth2laSB9+vTp8sVfs2YNIVIrhE+nTp3ksAtmj8mTJ0s/7RAQcKEMjQU8YOsZMWKEHM6Bj5lwL7QjRHpVWhZCSEPDgpEZ98P+iyix2HCOmTrIABDuC5XnU48CCBIOU4WIbY2C0XCMTwcNGkRwzQEwmBgBRiAwBLCHsk2bNvIPWg2MydA0Zs6cKTUMxRULfWvVqiXX3iFcEAjCC/ZYRO/A7gPEIcOMFozYCIxYRexOgF0WdpxevXopVm6/mCHDomJoTElJSfIahn6wC2H2CwEYJ06cKPd6QmP6/PPP6ZFHHpH7QbF0IFThuFxC7boUGNutiu4n0Iiw7ufrr7+WfwAG1nA0AFOHoZyag2qJahnjckPiYkxbtGhRfTmAew19PwMvrGMCr2AJU5aYqgwFL0QaMe61C7RuaBvG72XLlg2UhX4feOFBxssRDOELDaxgL/SHFwIBwugayQS/Wt7sqJjdwrS5cUoceOB5wXNnHg5hQSMwDtTBfkZGhnw/MHwzU6ieUcXXowakMqhfNBJq2UsvvSTVP6w1wPAMFvt+/fqpbPzLCDACfiLgTfiAFQSBWfggHR8rs/BBOkwlgQof3I+yrIQProXiAwk+irwaoVUm9QutxBgZFS5ZMe5kYgQYAUYgEAR80oA4Mmog0PI9jAAjkBMCXgUQR0bNCT6+zggwAsEg4FEAwejMkVGDgZbvZQQYgZwQ8GgDgnGLI6PmBB9fZwQYgWAQ8CiAwNTKwp5TYaGIjArtC9PImPJTpFYLYJ2DMRKruu7PL3hhqtHI35/7jXnBB9P6oeCFqepQ8EGd0MZQ8cIK3UCeBSNO6FMQpoj94YW2MEUuAl4FUF41Gw8olo4bp/zUOiCkK7cggdYvWtYBGfELFKtQrwPCFLE/64Cspp8DbQvfZz8EvAoghF1OTk7OsdZYqYlNcUyMACPACPiDgFcBhK382AdWqlQpuS/ME2OshmYB5AkdTmcEGAFPCHgVQB9++KF0DYDNZ9ilG4rtBp4qwumMACMQfQh4nIYHFNiEhg1wWJaNLRhMjAAjwAiEEgGvAggFwQj46aefyi3+oSyYeTECTkIgU8t0UnUdU1evQzDVCmzPxx8TIxCNCCSnn6Yn1gylDxqPCUnzMQsLd6dmwjvWpk0b6SgMXgcxY2gMBmE8Nt/r6XzHjh3SFSvc6tiRctSAjJWGZzU4t4Z7ACZGIFoQGLF5Ii06tJS+OPB1SJoMX1pwe4pJHoThUX/Y+gSCTyCsl4KzMOW4HmvE4JPLX4ILHfh1tiv5pAGpymNB2g8//MDOyBQg/BvxCGxL2Ukf7p4h2zls40hqW7YN5Y/N7qw+ECBGjhzpttZN8cDkD7QfuEDGMhgIIyzM3b17t/SgiFlpEFy0bt++XToWQ34jIZy6WvxpTLfbsV8akN0qz/VhBMKNwNANw0nZf/afP0STtk8Jd5HS8yg8UMBJPFyswuPha6+9JgUKolNgdTi0I3g+HDhwIFWuXNnNaRtC5zRp0oRuuukmGjt2bNjrG0wBPmlAiEkE7QdjVxAc1GO1MjzlYYzJxAhEIgLfHPmRvj/6i1vTxm2fTD0r3Unl8wfvbRL2HuNKbzj3U1uZ4B4VrlfhDhnx+WD/wVBK+WVGtBpErUHILGg7iHQB5/JffvmlXDIDf87gbff1eT4JIKiKED5wHYmx67Bhw+SaIAWWWw/xCSMQAQhA6xm1ZRIVjiuUrTVjt71Pw+u9kC3d34Tx48fr0Uhxr6/vE2yxP//8M02bNk06rce9sMsiPhg0Jhic1XaXDh060DfffIMstiSfBJAKkrZ//37ZCFjoETGDiRGIVARiXbH0VauZYW0ejMqB7teDgMFQS4VXRkQNhNRBOmxDitR1dW63X7YB2a1HuD6MwD8IwK+z8vygNBrMoMEIjYgYmDWDn3ZEt8DwC7YhBIpA4Ah4QsD53LlzbY2nXwIIWg9C9eTkRNvWLebKMQIOQQBhsBAyGXYcDM8QggeBDGHzQVgfhOapV68etW3bVoZaRhQU2IIGDBggp+yxSdzuGpBPQzDVX2gMGmymQBZImXnwOSMQLQjAnYzyb2XV5n379unJCGWkYvBhCcy5c+dkTC4oA9CAYA9S0/Lqpueee46efPJJqQGpmF/qmt1+fdaA7rrrLmmENjcALjsgcZkYAUYg9AhgttkYYsccENAsfFQNMENtd+GDuvosgBAHDNEWf/zxR9lGBAlEWB6sQzDGolYA8C8jwAgwAjkh4LMAQjhmBCLEFB+Wh9etW1dqRFhGjuiVTIwAI8AI+IuAzzYgWOGx/mfr1q1yQRSmDxEyF4HrmRgBRoARCAQBnzUgbJzDCmis1sTUHlZgNmjQgEaNGuWIPSeBgMP3MAKMQHgR8FkA3XrrrXTllVfSunXrqHPnzjRr1iypCWE68NFHHw1vLZk7I8AIRCQCXgXQgQMH9EZjY9zs2bPdVm5iYxzWBdWoUUPPB2M1EyPACDACviDgUQBhnQK2YAwZMkQufOrWrZslP+zIffzxx2nBggVyodSIESMs83EiI8AIMAJmBDwaoeEPGpvbJk+eLG098NYGuw+WfV922WXSR8nmzZsJf7APIT/sQe3btzeXweeMACPACFgi4FEAITeWf2P3e+/evWncuHFym//7779Pe/fulYujMBXfsGFDuSS8V69ebq4FLEvjREaAEWAEDAh4FUAqH6KRDh48WP4hDeGRsTrT6MtE5eVfRoARYAR8RcCjDQgMhg8fLu0/OFa7cnEMgcTCB0gwMQKMQDAIeBVA8MQGz2og7MI9depUMGXxvYwAI8AIuCHgdQgGh0mwAcH4DCdH2P6PTW5mwh6xPn36mJP5nBFwQyBLy3I7N55sSdlBCTH5qEpSJWNyRB5jNDF9+nS9bXinqlatKvdUYjInUMLMNWy0999/v/SMCDMJXHp4I+XJAhNOvuT3xiuQa14FEHzOwvcstl/AJeumTZss/Yuwf6BAoI+8e1Iz0+hMxlkqmVA8W+Pg4vSp7a/Q+8VHUbz4z0wvrH9DRpuY2mSc+VKenR86SfTxT+7FQzw8ead7mr9niHSBD3v//v2lb3W424DT+WrVqtGiRYtkmr88kR9RMMAXnhLhmrVIkSJeBRA2ksN/EBYW+5I/kDrldI9XAQSHRlOnTpU8sA0DYULM4T9yKoCvRxYCPwgn7W1Kt7Bs1MTtHxIiR4y6+uVs16fvnUPfn/qFPtj9CT1W+36364sPf08/HftVpi07toJalrrW7XpenZw+T/TLpuylByuAFMcJEybotlRM7JQuXZrWrFkjN3pDM0EsMGg1cFCPXyzyxZ5MLIMxEgJGwDcQtChFEEJGbQoKBAJIIMAEZrfBf+PGjVJA4X5zfvCB+QV+h9Q7jzrCJxgEJnwWYWlOsLZgrzYg1Rj8Yte7qogxnY8jC4EjqccI0SCsaN+5g9Tn90fp2yPLsl0+dP4IIWLEjL2f0bpk97f21IVkGrltkrzn7R2T6Vjqcf3+C1np9OKGN/VzaEIqDI6eGAUHEDAQDHjHoI0gACg++nC5Cveq+MViYLhcxQJh5AdBKShfvrwUILimaOjQoTRmzMVIrnBgD2+JDz/8sNxOhcgaiJ4BYff222/T8uXLyZh//vz50qMiNDQIu0mTLvbdCy+8QD169JDrAmFywTIcxCwLhnwWQMEUwvfaC4EZez+ndPHiW9Frm0bTc2tfIwynzPTKxrcoLeuCFBjm+4dtHEXnM1NJE/8NWfdft1tHbJlAp9KTZdqZzLP0381v69ff3zmddp+95AFwc8p2mrp7ln49kg+wvQkO/V555RUZw6tRo0bSsTzavH79ernAF+YPbIGCMFq1apXUSqAZYfEvfrEdCj6g4boVAsOKILgQQQPRMWB7mjFjBnXt2lXGDsNOBwg7RQiACJ6I2AEXPNj7+dJLL8mykAeBEFEnbEovVKgQLVmyRN0a0C8LoIBgs/dNEBJ/nv7LspJ7zx2gQWuH0eSdH2e7vvrvdTRr33zad/4gvbNjitv1X0/8SQsOXnzYtp/ZRR/umqFf//PkGvrswJf6+W8nV9G8A1/JcxiXp+z+VL+GAwjAtac2Sk1o9NZ33a7h5M3N4+hvoTVFOuHlXrt2rVxXhyEQ7D+KYA+qUKGCtAdBAOHF79u3L/Xr14/gDHDOnDnSJgv3rhBcIESrMQ67kIahUkpKipxIwnnjxo2lMMKxFcHOC2O00qaw8wFDraVLl8rs2JSuysBwDryDIa82oGAY873hRQAvaLH4IpaFfLhvJs3Y/xnddHkbSox1n7V8ZcNFLWbU1neo62W3U6mEEpIHVPrn11/SXN7ehgB8nSiJ8hNmr8xazVsiZlaXirdT8fiiNEQMm8yEMMa3lL2e3tj0tpjdipeaEUYNmORxif9e3zSWXqs7mN6sN9R8qzxPFhqTp/ZZ3hCGxGIFiW5v7M44iEkqd0biDLsLPNlQsNbOSLfccoub59FixYrJYRi0IBifMXzDH1y4GglaCtLVkA3XYPupU6eOMZt+jOEc7EWKJy7ADzUibICMYYRQlpGvzODnPyyA/ATMLtkfWPkUDazRn5qXdH9Djgr7yqQ9U+hcpoikKbSYgTUf0Ku8/PgftPDQxSB1KRlnpHAY+Y/BeO7+hbTq77V6XtyPYdUbNZ6nmfvn0YbTW/RrODidkUJviKFUv6q9qUbBavLPLYM4WXNqPX3Y5GJoYLwocLCOGVMVYgb5Ly9YBT+2pNJCvt97U95XDXaXxYsXS/fHMAJ36dKFOnXqJLdIQVuBTQfaD7QiCA8jFS1alJo3by43i2PYhZDOWE6DIRzuhTHaSBBAcDKIzeWwNWEoiD9sucK9oaZcFUCwosN9R4sW1rMooW6ck/llZGXQ0iM/UbtyN2RrxteHvpOzRsfTTtLS1rMpxnXpqwcbDoQHSGkxZRNLX9RiTJrKJ8Jg3LdqT6qWVJleFfeZCUKpZ+k7qUR8cRpZ/2XzZULwvpqFqtG4Bq9nu8YJoUOge/fu0glglSpV5IwY/HJh7yWGQp9//rk0DD/77LNyo7jZaT1qATsPhNirr74qhY6KF48peLhXNgsheD7F/k8YnRFxFTYjCKZwkEuoUBfN6eHgbuCJhYwAAmrbm29emvUwZNEPIX1RrY4dO+ppkOwY+0KiY9wbDIEXxq7glRNlnThOWSIibEzlKhRjkR9fdajRvvDKqSzMdigVFzaa4cIW8uuNi9zW1WDWqOV3HWnPuYuG2xH1XqS7qlx0lQIbTvtlvdyK6VLxNprQ4A2aJgy7z6x9xe0aTq4t3pA+EFrKptNbs11DQuHMglSr2MWIm5YZfEz0pAHldDv8jcP1L5PQOsWME7RHaC5mMj475mvqHKHVzWv28F6Cp3nohnusQv4oXqH6zRUNCOsXEKsIC6Pw5xRK/2UZpf3vfRJ6LVF8AiU+/CjFXX1NyKoPTaZR8avdBAyYw76DmSM5TBLDnLfqv6SX+d6OabrwQSKGQXdUaEeF4gpa2mKgxdxbpRc1LFaPPm8xRedjPEiKLUAtSjYxJunHwRoZdUZ8EDQC3pbBqA+Xt0LMwgd5rYSZ4uEp5I+6HorfXBFAMGJh3AkJbLT0Gxvw0Ucf6aeHDx+mypUrE6YEFcEoBsKiKXWsrvn7i/thVDPyN/PQLohp6Cniy6vG1OI8FcLov2/qswC4R425vfEy88Y5pqwHrX2VWpdoRq/XeU5mAS/weW3LaEpOv7i+4uM9c6lnmTuoTqGadCztBJlnjU5c+Jv+u/5teqTqPdS1TAf5ly7ahvbl/+dLmXIuhWoLLYY89HZGajplULpVNeWiM2ij0GCCIYWTWmDnKy91n6/5OZ+zEPDwSIa2EdhTBvpBRHa0IjzgGHcqwv4VrAq1WuSEB9g8ZlX3+fvr7aVynfqbCooVn250OplSxDBJLAd1S4ZA88TrYNoRKp9Qxi0/Tibun0KH047SrIPzqVOxdlSrgBAQglYd/os+ETNYirCu5sVNI2hy7ZH05bEldFVSLXVJ/916ejudTTlH7Qpdr6eZD6ywNOfxdK4ic3q67k86Pkb+EAsgf9ByXt5cEUA5wQJjGjwrKlq4cKHUcrB6UxEeRIxJYWvxpjaq/N5+wStHG5Ao+3yVqpS1e5fOKrZefSprWgbvzQa0PnkzPbD+afqxzRdUIO6S3Wr/uUM0/cgcyRcCZsyhyXJ4hHH82F3/oyzxn5FWpqylP7LW0oC6/WgA9TNesjyGsR+aFJbRB0vACZsljTNXgfCEgIYGjKGCP7z8yRtIvfievEXAFgIIEKjFTQoOnBvTPB2r/P78Kt5Gnlb3Jz7+BKV9NJ2y9uyi2Jq1KaH3v93qhHu88Rq6YbjcGzVhxwf0TO1H9CKGbRpJqVliiPcPrTi5khYcWkKN8tWjvlV6yD91Tf2WTiiZrWx1zdNvTu3zdJ8x3Vv7jPlyOlZ1Ufxyys/XowMB2wggO8IdU7wE5X9soNeqHb8gvuoxxbLlmX9wMWH1MAibNP9VqQtVLFCOVpxYSbhmJiwQXHDNNLqtfFvzJT5nBCIWARZAQXbtm7snUq2C1enZ4pdio2EfFQSKImg72Ef1XqORcuXx3ObCuG1BqWILBRMjEE0I5KoAatOmDeEvUgh7oBYd/5Z+OLmc+tbsSWUSS8mmTdpx0S2FsZ3Qeu498S+6tkRDj6t/YQNiYgSiCYFcFUB2BDb9++/owpcLsEGJ4jt0pHxtPM8kGeuPmTu1B+pc1nl6deNouSIYriSwHaLHZXcYs8vjtac2SAGU7QInMAJRikBUC6CMtX9R2pT/6V2f9uFkcgnnT3FX1dXTcICd2/WKXuGW9um+L+ReJ5U4e/98uqdqL2pQrC79t94Qlcy/jAAj4AWBS5uIvGSK1EuZa1Zna1rm6lVuaRuTt9Cdv/QhTJ0rOptxjrDnykxDxG5yaEZMjAAj4BsCUa0BucRiRzO5TGtnMMy6uDN8JL3b6KJhefWpdXRzmdbyVuylcYn9bQliPw1o59k9Hm08MgP/wwgwAjoCUS2A8t14M2WK3fmZG9dLQGLF0CvfDTfp4CwUDriWn/hDnn9x8GtpRG5aogFdV7Kp/MMFbwsRdUZ8wAgwApYIRLUAcoktFYnPDBKrnXdLcGKqVNEX+8mpdOFUy0gYYi1u9amb+wvjdT5mBBgB/xCIahsQoMLK3PRK5SmjUgVd+CD93R1TCe5LjQRn63AnysQIMAKhQSCqNSAFITwHxgjnWo/VuE8lUbxwI/pUrQH6uTrI0C66plTn/MsIMAKBIxD1Auhw6lHpORAQYu2OWkz4UPW+gaPKdzICjIBPCET9EAwLCDHLhT+rqXWfUORMjAAjEBACUS2AVgon7HP2i1XQ/xBC0sCtKRMjwAjkDgJRK4CwYPAFUwA9QI51P7yYMHcePi6FEYhaG9CalA3S0Ayn7GZaJRYawodyXlLmju2UdfwYxda5gmIKF/GvKtu3UZxw3qaJmFCupCT/7g1Tbu3IEYpbt5Y0EdGBKlUOUynM1mkIRK0AuqbwVTTvuqm27K+0j6dT+pKvL9atQAHK/9SzFHt5dZ/qmvruRHIt/4UQN+HcgnmUf7CIRFK+gk/3hitTuqjPhcnvUn7hiTJdrBqP6XOvz5t+w1Un5msPBKJmCDZz7zx7IJ5DLTL37b0kfJBX+FBOm5E9jLIVm4yNGyhDvOyKNBHGJW2We1hkdS23fjUhdNKmT7nk3F/4z4aA1cz+tnOrQlyOrRCICgEEvz0D1wyRgf5shb5FZbTk7DHRtVOnLHJmT7K8N/nv7BlzMwWCxuyIXkQY0VLdI3LmZpW4LPsgEPECyOi358X1b1K6COxnZ4qtUYNcwhWskeKubWY89Xgs3YgkFXS7Hndtc7fz3D5xiSCSsfXdY6kFZNfK7YpzebmCQMQLIKPfnh1nd9MHu2bkCrCBFuJKSKT8g56j2IaNKEYYa+M7d6X4Tl18YucSRuf8g54n7YqrKLNCRYrv1Zvy3XyLT/eGM1PigwMoRjh6yyxXjmKua0WJjzwezuKYt4MQiGgjtJXfnre2TKRO5dpTPLnH9rJTn8WUKSuc4T8RUJViK1UiGvAInRdheYoYwhoFxCxEN7mEIT3fv/tQ8vHjMjSw6x/XJSFiz2wcjEBEa0Bjtr4ro4ka+wfhjodvHW9MCvhYS0ulmL9Wk2v9OtKEcTW3CMZlzCzB6JyblHXsKCFcdaYhVlooyodBOuPP3ylj5Z+kiYiuTNGDQERrQDeUaan77XHr0hA4LcwSxuLzr7xI8WKtDuj8D9/J4Y8rLryQZu7ZTeeHv04i8qAsN67FdZTY/yF5HM5/MlatpNQJb5OI+SyLie/SneI73hF0kZowUJ8b9hJpBy96HsCwM/+QoYShKFPkIxDetyWP8WtWopFlDVRkVMuLPiamL/yCtH+ED27J2raVMn5eFvb1LRdmzdSFD8rN+OVnymxzgwicWAunYaO06WLNlEE7ufDZbIpr3YZiivi5SNJUw/TFX+nCB5ey9u6h9G+XUvytt5ly8mkkIhDRQ7BwdhiGQWbSROz4cFOelZtiai98X59JCbq5WZY4msoKuhRmYFcEIkYAwS6RKbSQ3LLFxDVr4d6nYugV17iJe1oYzuKau5frEhpIbB2xvSHMZG5vTJWq5CpXPuhS8zUzLRMQDuLiml4bNF9m4AwEHD8Eg8BJHT+WMoUBExRTrRrlf+Y5wvqTcFLc1ddQAmabvlokAorFU1LX7hQTghcypzrnu6W9aGQMZaz4lVzFilFC1x65st8r4a4+5CpcmDI3rKcYTPF37ymd8edU35yuY+iY+MSTlA4chfDJ1+F2iq1aLafb+HqEIOB4AYStB0r4ZLg0itu5ky4sWkgJXbqFvYvyNW1GyZfXoDih/cQWLRr28lAAInDECyGEv9wkTJ0ndOtBhL8QU9zVDQh/TNGHgOOHYJgaBi0uf4om17x4rB09En09yS1mBByIgOMFEIZCabGaiEZ6iCbVOkrHEtIptkF2FxsO7BuuMiMQ8Qg4XgDBXjDt39Vpf9IFOpsvi0Z1FKtuxdCIiRFgBOyPgOMF0JHUYzTu/Fc60rOz/mS3qjoafMAI2BsBxwsg5VTeCDPcqjIxAoyA/RFwtADakrKDlh1fQWUSSrn97T930BG+f+z/eHANGYHwIuDoafhahS6nNW2/Cy9CzJ0RYATChoCjBVDYUAkR48zNmyjr4EGKvUI4li9bLkRcw8cGizqxpko7f47ixEyiq2Ch8BXGnBkBgQALoDA9BmmfzqB0sSBSUmwsJT78GMUJJ2N2Jfhuxi77rC2bZRUvCF/S+V94iUj48mFiBMKFgC0FENyoYsd6evol96lZ//jbMaf7Agx2WGs7dpCrcmWxVeNyAi/8Gfn7wscqD+pq5qWdOHFJ+OAm0ZbUTz6ihHr1rVjoaWY++gU/D8AH5E/7MsXWDiV8cK8mNp+mzptLWT17i03wGWKXhAvJARN4gPzlxTHaAobcETfaUgABuQvCSdX585ccl6uXCunq2CeEhbsK16efkAu7twVl3dmZtBtukgLOyN8nXhaZVF3ceJ08SWbrvnb2jFt7LFjJdrnxscrkQxoED15cv3gJx/fmOmcmC8dnghfaqASID8VbZsGHA5SWluYXL4WvJVNOdDwCthRA+NrmF5tJC4vNj4rwAOOFQjr+fCHYNM7O+0x8zi95IItZ8AUltm0nX1Ajf1/4WeWBQMReMCMvrXZtOl+lKmUZPAfGt2xNCYb2WPHCS27kY5XHl7SUlBT5kvvDK0s4Njv35XzhWe2S0M9/ww1ECQni/wSx3zbel6I95oEgS01NpSQRKNEfXrFi+MoUuQjYUgCFDG6o/cJtqhvhS4y0mPA92NgwimCCaXNnCyP0AYqrW4/yte/gVg27ncQUL075nx9KFyCwhRCKa309xTUS7kWEMGNiBMKFQEQLIOzgjhPbMjJWLNfxixXCwFVE7FwP84uFCBWJfe/Vy3XCQexllSj/owOdUFWuY4QgENECCH2U0O9+cpUuTVlbtxCcaMULG1DuuY+PkKeEm8EIhAmBiBdA0o+N2TfQPwbRMGHKbBkBRsBHBMwTHz7extkYAUaAEQgeARZAwWPIHBgBRiBABFgABQgc38YIMALBI8ACKHgMmQMjwAgEiAALoACB49sYAUYgeAQcMQv2/TqxnSrLRSmn84u9kbGULx9Ro+pEhXmfZPBPAHNgBPIQAUcIoLflpnIoa5dC37xxNwugPHxuuGhGICQI8BAsJDAyE0aAEQgEARZAgaDG9zACjEBIEGABFBIYmQkjwAgEgoAjbEAVSwg/PsKlBlxyxIqd5i6XCE/siJoH0iV8DyMQPQg44jUe1x9OBbPo6NFjVFTEYPfVH1D0dCO3lBFwJgI8BHNmv3GtGYGIQIAFUER0IzeCEXAmAiyAnNlvXGtGICIQYAEUEd3IjWAEnIkACyBn9hvXmhGICARsOwv2wQcf0KJFi3SQEWYGIV3yiY1gwUZKAC9EoACvYAlRMRDFIxS8EDkiFHzQNixZQDSLYAm8YsTSB/wFQ6r/EBHDH167du0Kpli+1+YIiHBZhpg1NqqsuVrHjh2j1q1b05gxY6ht27a2qWn37t2pevXq9Prrr9umThMnTqTp06fTr7/+aps6bd68mTp37kwfffQRNWjQwOd6BRsQ0eeCOGOeIGBbDcjqwVNB6qyu5Ql6olDUCX92qhOEt93qhP6xY//l1XPD5V5EIDi9mlFkBBgBRiAIBGyrAZnblJiYSO3ataOyZcuaL+XpefPmzW1XJwwJb7zxxjzFxVx4IREnDf1XrFgx8yU+j2IEbGsDiuI+4aYzAlGDAA/BoqaruaGMgP0QcMwQ7Pjx47Ry5UqqUqUK1apVK8+RPHPmDK1fv96tHtdee63beW6ffPPNN3T99SKme9ylbt2yZQvt2bNHzjyVLFkyt6tE5jrZEbdcB4UL1BG49KTqSfY7WL16NQ0dOlROv2OKuW/fvtSpU6c8regff/xB48ePl1PwqiJ5KYDmzp0rlyi0atVKF0CjR4+mDRs2UI0aNWjChAk0btw4qlSpkqpu2H+t6mQ33MIOAhfgFQFHCCCs/Xn11Vepfv36hHU39913H3Xo0IGwqC2vaNu2bdSxY0fq06dPXlVBlouFghDOJ06ccKvH7t27admyZTRnzhy58G/mzJn08ccf0+DBg93yhePEU51Qll1wC0e7maf/CNjeBoSHef/+/VSvXj3ZujJlyojIGAXowIED/rc2hHfgRSpYsCB98sknhK+6eeFkCIvyygornqF5QcMx0s6dOyVmatUxFv9t3LjRmCVsx57qhALtglvYGs+M/ULA9gLo6Ow9jkMAAAOQSURBVNGjlJSU5LbQr0iRInTy5Em/GhrqzHiRVqxYIbc7TJs2jZ5++ulQF+ETP2y3gCZmtPvgxkOHDhFwUlS4cOFsWpK6FupfT3VCOXbBLdRtZn6BIWD7IRj2feGLaiRoRVgXlJeEvWrwzggN4/bbb6c77rhDamoVK1bMy2rpZZtxA2Z28CRpd9x0APkgVxCwvQZUokQJOnv2rNyIqhCB9lO+fHl1muu/2ICKmSU1vIEtCkPDw4cP53pdPBVYqlQpNy0RmJUrV85T9lxJdwJuuQIEF6IjYHsBhKFF06ZNaf78+bLSP/30k1xNm5crarFjfdSoUXIIhkpt2rRJDm+uvvpqHdi8PmjcuLFcJrBv3z6583/BggXUpEmTPK2WE3DLU4CisHBHrISGtvHMM89INxzQOjDrU7NmzTztLqxJeu+99wguNLBTf9CgQdSiRYs8rVPLli1p6dKluhuOhQsXyqn34sWLU+XKleVMotlWFO4Km+tkR9zCjQHz94yAIwSQqv6pU6ek3UWd2+E3OTmZYOC10254Iy4QkPCjhBk7O5HdcbMTVpFcF0cJoEjuCG4bIxCNCNjeBhSNncJtZgSiBQEWQNHS09xORsCGCLAAsmGncJUYgWhBgAVQtPQ0t5MRsCECLIBs2ClcJUYgWhBgARQtPc3tZARsiAALIBt2CleJEYgWBFgA2ainsfO/f//+tGTJEr1W8OnzwAMPEK4xMQKRhgALIBv1aOnSpeUu/7vvvltuJIWTsZ49exIiSuAaEyMQaQjwSmib9Whqaio1bNiQsJkU/pP37t1Lv/zyS0hCNtusqVwdRoBYANnwIVizZo30AACfR/CHXa1aNRvWkqvECASPAA/Bgscw5BywcRSuK+CIzeyMLeSFMUNGIA8RYA0oD8G3KhqeC+HWA+4zEEsd/rB//vnnbC5Xre7lNEbAaQjY3iWr0wANtr7Dhg2jXbt2EXz5QABdeeWVhLSXX345WNZ8PyNgOwRYA7JRl8DJ/XXXXUczZsygbt26yZoh6gZmxTAd36xZMxvVlqvCCASPAAug4DFkDowAIxAgAmyEDhA4vo0RYASCR4AFUPAYMgdGgBEIEAEWQAECx7cxAoxA8AiwAAoeQ+bACDACASLAAihA4Pg2RoARCB4BFkDBY8gcGAFGIEAEWAAFCBzfxggwAsEjwAIoeAyZAyPACASIAAugAIHj2xgBRiB4BP4P+1NA+XZBE4cAAAAASUVORK5CYII=" /><!-- --></p>
+<p>Note that it is not a fit to the frequencies, it is a fit to the ratios of frequencies. You would never need to include this type of plot in one of your papers. It is solely for you to check for model misspecification. What’s model misspecification? If the model fit (pink circles) don’t remotely follow the pattern of the observed ratios (green triangles), that’s model misspecification.</p>
+<p>Sometimes, breakaway’s usual procedure doesn’t work, that is, it gives a negative estimate, which is of course silly. In that case, breakaway returns a different model’s result. It’s called the WLRM. There isn’t a picture. Here is an example of a case where breakaway returns the WLRM.</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1"><span class="kw">breakaway</span>(frequencytablelist[[<span class="dv">2</span>]])</a></code></pre></div>
+<pre><code>## Estimate of richness from method breakaway:
+##   Estimate is 346
+##  with standard error 42.82
+##   Confidence interval: (283, 2669)
+##   Cutoff:  15</code></pre>
+<p>breakaway can defer to the WLRM for several reasons. Perhaps there are too many singletons. Perhaps there isn’t a long enough tail. Perhaps there is false diversity. Regardless, we can see if this failure was sensitive to the singleton count by running <code>breakaway_nof1()</code>. This requires no singleton count (implicit is that the singleton count was erroneous) and predicts it from the other frequencies:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb9-1" data-line-number="1"><span class="kw">breakaway_nof1</span>(frequencytablelist[[<span class="dv">2</span>]][<span class="op">-</span><span class="dv">1</span>,])</a></code></pre></div>
+<pre><code>## Estimate of richness from method PoissonModel:
+##   Estimate is 75
+##  with standard error 0.47
+##   Confidence interval: (75, 77)</code></pre>
+<p>The reference for <code>breakaway_nof1()</code> is: Willis, A. (2016). Species richness estimation with high diversity but spurious singletons.</p>
+<p>breakaway_nof1 is an exploratory tool for assessing sensitivity of breakaway to the singleton count. I recommend it as a sensitivity analysis rather than for diversity estimation.</p>
+</div>
+<div id="next-steps" class="section level2">
+<h2>Next steps</h2>
+<ul>
+<li>The above discussion focused exclusively on richness. Check out <code>github.com/adw96/DivNet</code> for alpha and beta diversity tutorials!</li>
+<li>To learn about modelling alpha diversity, see the vignette <em>Introduction to hypothesis testing for diversity</em></li>
+<li>To hear more details about how species richness estimation works, check out <em>Introduction to diversity estimation</em></li>
+</ul>
+</div>
+
+
+
+<!-- code folding -->
+
+
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+
+</body>
+</html>

--- a/vignettes/breakaway.html.asis
+++ b/vignettes/breakaway.html.asis
@@ -1,0 +1,3 @@
+%\VignetteIndexEntry{breakaway}
+%\VignetteEngine{R.rsp::asis}
+%\VignetteKeyword{breakaway}

--- a/vignettes/diversity-hypothesis-testing.html
+++ b/vignettes/diversity-hypothesis-testing.html
@@ -1,0 +1,764 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<style type="text/css">
+@font-face {
+font-family: octicons-link;
+src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==) format('woff');
+}
+body {
+-webkit-text-size-adjust: 100%;
+text-size-adjust: 100%;
+color: #333;
+font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-size: 16px;
+line-height: 1.6;
+word-wrap: break-word;
+}
+a {
+background-color: transparent;
+}
+a:active,
+a:hover {
+outline: 0;
+}
+strong {
+font-weight: bold;
+}
+h1 {
+font-size: 2em;
+margin: 0.67em 0;
+}
+img {
+border: 0;
+}
+hr {
+box-sizing: content-box;
+height: 0;
+}
+pre {
+overflow: auto;
+}
+code,
+kbd,
+pre {
+font-family: monospace, monospace;
+font-size: 1em;
+}
+input {
+color: inherit;
+font: inherit;
+margin: 0;
+}
+html input[disabled] {
+cursor: default;
+}
+input {
+line-height: normal;
+}
+input[type="checkbox"] {
+box-sizing: border-box;
+padding: 0;
+}
+table {
+border-collapse: collapse;
+border-spacing: 0;
+}
+td,
+th {
+padding: 0;
+}
+* {
+box-sizing: border-box;
+}
+input {
+font: 13px / 1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+a {
+color: #4078c0;
+text-decoration: none;
+}
+a:hover,
+a:active {
+text-decoration: underline;
+}
+hr {
+height: 0;
+margin: 15px 0;
+overflow: hidden;
+background: transparent;
+border: 0;
+border-bottom: 1px solid #ddd;
+}
+hr:before {
+display: table;
+content: "";
+}
+hr:after {
+display: table;
+clear: both;
+content: "";
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+margin-top: 15px;
+margin-bottom: 15px;
+line-height: 1.1;
+}
+h1 {
+font-size: 30px;
+}
+h2 {
+font-size: 21px;
+}
+h3 {
+font-size: 16px;
+}
+h4 {
+font-size: 14px;
+}
+h5 {
+font-size: 12px;
+}
+h6 {
+font-size: 11px;
+}
+blockquote {
+margin: 0;
+}
+ul,
+ol {
+padding: 0;
+margin-top: 0;
+margin-bottom: 0;
+}
+ol ol,
+ul ol {
+list-style-type: lower-roman;
+}
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
+list-style-type: lower-alpha;
+}
+dd {
+margin-left: 0;
+}
+code {
+font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+font-size: 12px;
+}
+pre {
+margin-top: 0;
+margin-bottom: 0;
+font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+.select::-ms-expand {
+opacity: 0;
+}
+.octicon {
+font: normal normal normal 16px/1 octicons-link;
+display: inline-block;
+text-decoration: none;
+text-rendering: auto;
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+-webkit-user-select: none;
+-moz-user-select: none;
+-ms-user-select: none;
+user-select: none;
+}
+.octicon-link:before {
+content: '\f05c';
+}
+.markdown-body:before {
+display: table;
+content: "";
+}
+.markdown-body:after {
+display: table;
+clear: both;
+content: "";
+}
+.markdown-body>*:first-child {
+margin-top: 0 !important;
+}
+.markdown-body>*:last-child {
+margin-bottom: 0 !important;
+}
+a:not([href]) {
+color: inherit;
+text-decoration: none;
+}
+.anchor {
+display: inline-block;
+padding-right: 2px;
+margin-left: -18px;
+}
+.anchor:focus {
+outline: none;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+margin-top: 1em;
+margin-bottom: 16px;
+font-weight: bold;
+line-height: 1.4;
+}
+h1 .octicon-link,
+h2 .octicon-link,
+h3 .octicon-link,
+h4 .octicon-link,
+h5 .octicon-link,
+h6 .octicon-link {
+color: #000;
+vertical-align: middle;
+visibility: hidden;
+}
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
+text-decoration: none;
+}
+h1:hover .anchor .octicon-link,
+h2:hover .anchor .octicon-link,
+h3:hover .anchor .octicon-link,
+h4:hover .anchor .octicon-link,
+h5:hover .anchor .octicon-link,
+h6:hover .anchor .octicon-link {
+visibility: visible;
+}
+h1 {
+padding-bottom: 0.3em;
+font-size: 2.25em;
+line-height: 1.2;
+border-bottom: 1px solid #eee;
+}
+h1 .anchor {
+line-height: 1;
+}
+h2 {
+padding-bottom: 0.3em;
+font-size: 1.75em;
+line-height: 1.225;
+border-bottom: 1px solid #eee;
+}
+h2 .anchor {
+line-height: 1;
+}
+h3 {
+font-size: 1.5em;
+line-height: 1.43;
+}
+h3 .anchor {
+line-height: 1.2;
+}
+h4 {
+font-size: 1.25em;
+}
+h4 .anchor {
+line-height: 1.2;
+}
+h5 {
+font-size: 1em;
+}
+h5 .anchor {
+line-height: 1.1;
+}
+h6 {
+font-size: 1em;
+color: #777;
+}
+h6 .anchor {
+line-height: 1.1;
+}
+p,
+blockquote,
+ul,
+ol,
+dl,
+table,
+pre {
+margin-top: 0;
+margin-bottom: 16px;
+}
+hr {
+height: 4px;
+padding: 0;
+margin: 16px 0;
+background-color: #e7e7e7;
+border: 0 none;
+}
+ul,
+ol {
+padding-left: 2em;
+}
+ul ul,
+ul ol,
+ol ol,
+ol ul {
+margin-top: 0;
+margin-bottom: 0;
+}
+li>p {
+margin-top: 16px;
+}
+dl {
+padding: 0;
+}
+dl dt {
+padding: 0;
+margin-top: 16px;
+font-size: 1em;
+font-style: italic;
+font-weight: bold;
+}
+dl dd {
+padding: 0 16px;
+margin-bottom: 16px;
+}
+blockquote {
+padding: 0 15px;
+color: #777;
+border-left: 4px solid #ddd;
+}
+blockquote>:first-child {
+margin-top: 0;
+}
+blockquote>:last-child {
+margin-bottom: 0;
+}
+table {
+display: block;
+width: 100%;
+overflow: auto;
+word-break: normal;
+word-break: keep-all;
+}
+table th {
+font-weight: bold;
+}
+table th,
+table td {
+padding: 6px 13px;
+border: 1px solid #ddd;
+}
+table tr {
+background-color: #fff;
+border-top: 1px solid #ccc;
+}
+table tr:nth-child(2n) {
+background-color: #f8f8f8;
+}
+img {
+max-width: 100%;
+box-sizing: content-box;
+background-color: #fff;
+}
+code {
+padding: 0;
+padding-top: 0.2em;
+padding-bottom: 0.2em;
+margin: 0;
+font-size: 85%;
+background-color: rgba(0,0,0,0.04);
+border-radius: 3px;
+}
+code:before,
+code:after {
+letter-spacing: -0.2em;
+content: "\00a0";
+}
+pre>code {
+padding: 0;
+margin: 0;
+font-size: 100%;
+word-break: normal;
+white-space: pre;
+background: transparent;
+border: 0;
+}
+.highlight {
+margin-bottom: 16px;
+}
+.highlight pre,
+pre {
+padding: 16px;
+overflow: auto;
+font-size: 85%;
+line-height: 1.45;
+background-color: #f7f7f7;
+border-radius: 3px;
+}
+.highlight pre {
+margin-bottom: 0;
+word-break: normal;
+}
+pre {
+word-wrap: normal;
+}
+pre code {
+display: inline;
+max-width: initial;
+padding: 0;
+margin: 0;
+overflow: initial;
+line-height: inherit;
+word-wrap: normal;
+background-color: transparent;
+border: 0;
+}
+pre code:before,
+pre code:after {
+content: normal;
+}
+kbd {
+display: inline-block;
+padding: 3px 5px;
+font-size: 11px;
+line-height: 10px;
+color: #555;
+vertical-align: middle;
+background-color: #fcfcfc;
+border: solid 1px #ccc;
+border-bottom-color: #bbb;
+border-radius: 3px;
+box-shadow: inset 0 -1px 0 #bbb;
+}
+.pl-c {
+color: #969896;
+}
+.pl-c1,
+.pl-s .pl-v {
+color: #0086b3;
+}
+.pl-e,
+.pl-en {
+color: #795da3;
+}
+.pl-s .pl-s1,
+.pl-smi {
+color: #333;
+}
+.pl-ent {
+color: #63a35c;
+}
+.pl-k {
+color: #a71d5d;
+}
+.pl-pds,
+.pl-s,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sra,
+.pl-sr .pl-sre {
+color: #183691;
+}
+.pl-v {
+color: #ed6a43;
+}
+.pl-id {
+color: #b52a1d;
+}
+.pl-ii {
+background-color: #b52a1d;
+color: #f8f8f8;
+}
+.pl-sr .pl-cce {
+color: #63a35c;
+font-weight: bold;
+}
+.pl-ml {
+color: #693a17;
+}
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
+color: #1d3e81;
+font-weight: bold;
+}
+.pl-mq {
+color: #008080;
+}
+.pl-mi {
+color: #333;
+font-style: italic;
+}
+.pl-mb {
+color: #333;
+font-weight: bold;
+}
+.pl-md {
+background-color: #ffecec;
+color: #bd2c00;
+}
+.pl-mi1 {
+background-color: #eaffea;
+color: #55a532;
+}
+.pl-mdr {
+color: #795da3;
+font-weight: bold;
+}
+.pl-mo {
+color: #1d3e81;
+}
+kbd {
+display: inline-block;
+padding: 3px 5px;
+font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+line-height: 10px;
+color: #555;
+vertical-align: middle;
+background-color: #fcfcfc;
+border: solid 1px #ccc;
+border-bottom-color: #bbb;
+border-radius: 3px;
+box-shadow: inset 0 -1px 0 #bbb;
+}
+.task-list-item {
+list-style-type: none;
+}
+.task-list-item+.task-list-item {
+margin-top: 3px;
+}
+.task-list-item input {
+margin: 0 0.35em 0.25em -1.6em;
+vertical-align: middle;
+}
+:checked+.radio-label {
+z-index: 1;
+position: relative;
+border-color: #4078c0;
+}
+.sourceLine {
+display: inline-block;
+}
+code .kw { color: #000000; }
+code .dt { color: #ed6a43; }
+code .dv { color: #009999; }
+code .bn { color: #009999; }
+code .fl { color: #009999; }
+code .ch { color: #009999; }
+code .st { color: #183691; }
+code .co { color: #969896; }
+code .ot { color: #0086b3; }
+code .al { color: #a61717; }
+code .fu { color: #63a35c; }
+code .er { color: #a61717; background-color: #e3d2d2; }
+code .wa { color: #000000; }
+code .cn { color: #008080; }
+code .sc { color: #008080; }
+code .vs { color: #183691; }
+code .ss { color: #183691; }
+code .im { color: #000000; }
+code .va {color: #008080; }
+code .cf { color: #000000; }
+code .op { color: #000000; }
+code .bu { color: #000000; }
+code .ex { color: #000000; }
+code .pp { color: #999999; }
+code .at { color: #008080; }
+code .do { color: #969896; }
+code .an { color: #008080; }
+code .cv { color: #008080; }
+code .in { color: #008080; }
+</style>
+<style>
+body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+  padding-top: 0px;
+}
+</style>
+
+</head>
+
+<body>
+
+<h1 id="introduction-to-hypothesis-testing-for-diversity">Introduction to hypothesis testing for diversity</h1>
+<p>Amy Willis 2021-10-21</p>
+<p>This tutorial will talk through hypothesis testing for alpha diversity indices using the functions <code>betta</code> and <code>betta_random</code>.</p>
+<h2 id="disclaimer">Disclaimer</h2>
+<p><em>Disclaimer</em>: If you have not taken a introductory statistics class or devoted serious time to learning introductory statistics, I strongly encourage you to reconsider doing so before ever quoting a p-value or doing modeling of any kind. An introductory statistics class will teach you valuable skills that will serve you well throughout your entire scientific career, including the use and abuse of p-values in science, how to responsibly fit models and test null hypotheses, and an appreciation for how easy it is to inflate the statistical significance of a result. Please equip yourself with the statistical skills and scepticism necessary to responsibly test and discuss null hypothesis significance testing.</p>
+<h2 id="preliminaries">Preliminaries</h2>
+<p>Download the latest version of the package from github.</p>
+<p>Let’s use the Whitman et al dataset from <code>corncob</code> as our example.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="co"># remotes::install_github(&quot;bryandmartin/corncob&quot;)</span></a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="kw">library</span>(corncob)</a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw">data</span>(<span class="st">&quot;soil_phylo&quot;</span>)</a>
+<a class="sourceLine" id="cb1-4" data-line-number="4">soil_phylo <span class="op">%&gt;%</span><span class="st"> </span>sample_data <span class="op">%&gt;%</span><span class="st"> </span>head</a></code></pre></div>
+<pre><code>##      Plants DayAmdmt Amdmt ID Day
+## S009      1       01     1  D   0
+## S204      1       21     1  D   2
+## S112      0       11     1  B   1
+## S247      0       22     2  F   2
+## S026      0       00     0  A   0
+## S023      1       00     0  C   0
+</code></pre>
+<p>I’m only going to consider samples amended with biochar, and I want to look at the effect of <code>Day</code>. This will tell us how much diversity in the soil changed from Day 0 to Day 82. (Just to be confusing, Day 82 is called Day 2 in the dataset.)</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1">subset_soil &lt;-<span class="st"> </span>soil_phylo <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"><span class="st">  </span><span class="kw">subset_samples</span>(Amdmt <span class="op">==</span><span class="st"> </span><span class="dv">1</span>) <span class="op">%&gt;%</span><span class="st"> </span><span class="co"># only biochar</span></a>
+<a class="sourceLine" id="cb3-3" data-line-number="3"><span class="st">  </span><span class="kw">subset_samples</span>(Day <span class="op">%in%</span><span class="st"> </span><span class="kw">c</span>(<span class="dv">0</span>, <span class="dv">2</span>))  <span class="co"># only Days 0 and 82</span></a></code></pre></div>
+<p>I now run breakaway on these samples to get richness estimates, and plot them.</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">richness_soil &lt;-<span class="st"> </span>subset_soil <span class="op">%&gt;%</span><span class="st"> </span>breakaway</a>
+<a class="sourceLine" id="cb4-2" data-line-number="2"><span class="kw">plot</span>(richness_soil, <span class="dt">physeq=</span>subset_soil, <span class="dt">color=</span><span class="st">&quot;Day&quot;</span>, <span class="dt">shape =</span> <span class="st">&quot;ID&quot;</span>)</a></code></pre></div>
+<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqAAAAHgCAYAAAB6jN80AAAEGWlDQ1BrQ0dDb2xvclNwYWNlR2VuZXJpY1JHQgAAOI2NVV1oHFUUPrtzZyMkzlNsNIV0qD8NJQ2TVjShtLp/3d02bpZJNtoi6GT27s6Yyc44M7v9oU9FUHwx6psUxL+3gCAo9Q/bPrQvlQol2tQgKD60+INQ6Ium65k7M5lpurHeZe58853vnnvuuWfvBei5qliWkRQBFpquLRcy4nOHj4g9K5CEh6AXBqFXUR0rXalMAjZPC3e1W99Dwntf2dXd/p+tt0YdFSBxH2Kz5qgLiI8B8KdVy3YBevqRHz/qWh72Yui3MUDEL3q44WPXw3M+fo1pZuQs4tOIBVVTaoiXEI/MxfhGDPsxsNZfoE1q66ro5aJim3XdoLFw72H+n23BaIXzbcOnz5mfPoTvYVz7KzUl5+FRxEuqkp9G/Ajia219thzg25abkRE/BpDc3pqvphHvRFys2weqvp+krbWKIX7nhDbzLOItiM8358pTwdirqpPFnMF2xLc1WvLyOwTAibpbmvHHcvttU57y5+XqNZrLe3lE/Pq8eUj2fXKfOe3pfOjzhJYtB/yll5SDFcSDiH+hRkH25+L+sdxKEAMZahrlSX8ukqMOWy/jXW2m6M9LDBc31B9LFuv6gVKg/0Szi3KAr1kGq1GMjU/aLbnq6/lRxc4XfJ98hTargX++DbMJBSiYMIe9Ck1YAxFkKEAG3xbYaKmDDgYyFK0UGYpfoWYXG+fAPPI6tJnNwb7ClP7IyF+D+bjOtCpkhz6CFrIa/I6sFtNl8auFXGMTP34sNwI/JhkgEtmDz14ySfaRcTIBInmKPE32kxyyE2Tv+thKbEVePDfW/byMM1Kmm0XdObS7oGD/MypMXFPXrCwOtoYjyyn7BV29/MZfsVzpLDdRtuIZnbpXzvlf+ev8MvYr/Gqk4H/kV/G3csdazLuyTMPsbFhzd1UabQbjFvDRmcWJxR3zcfHkVw9GfpbJmeev9F08WW8uDkaslwX6avlWGU6NRKz0g/SHtCy9J30o/ca9zX3Kfc19zn3BXQKRO8ud477hLnAfc1/G9mrzGlrfexZ5GLdn6ZZrrEohI2wVHhZywjbhUWEy8icMCGNCUdiBlq3r+xafL549HQ5jH+an+1y+LlYBifuxAvRN/lVVVOlwlCkdVm9NOL5BE4wkQ2SMlDZU97hX86EilU/lUmkQUztTE6mx1EEPh7OmdqBtAvv8HdWpbrJS6tJj3n0CWdM6busNzRV3S9KTYhqvNiqWmuroiKgYhshMjmhTh9ptWhsF7970j/SbMrsPE1suR5z7DMC+P/Hs+y7ijrQAlhyAgccjbhjPygfeBTjzhNqy28EdkUh8C+DU9+z2v/oyeH791OncxHOs5y2AtTc7nb/f73TWPkD/qwBnjX8BoJ98VQNcC+8AAAA4ZVhJZk1NACoAAAAIAAGHaQAEAAAAAQAAABoAAAAAAAKgAgAEAAAAAQAAAqCgAwAEAAAAAQAAAeAAAAAAEl/b3AAAQABJREFUeAHs3Ql8FdXd//FfEpawg4IIVUGruEDFHbX+FbAoFhd8HnGp2rq21ke07rtWRItFrbXWDVtxA8ENEVHR4oJaQJHqU0DEirIIspOErCT5z/eEuc9NyL2ZzNwkN8nn8Lrk3rkzZ868z7lzf/fMzJmMci8ZCQEEEEAAAQQQQACBehLIrKf1sBoEEEAAAQQQQAABBJwAASgNAQEEEEAAAQQQQKBeBQhA65WblSGAAAIIIIAAAggQgNIGEEAAAQQQQAABBOpVgAC0XrlZGQIIIIAAAggggAABKG0AAQQQQAABBBBAoF4FWtTr2tJwZddee63l5eUlLVlpaal7PysrK+l8id7USFfKQ8tnZGQkmi3pdMpQwZMWDt9/7xWm3LJ6/ihpnSV6k/ZQIYMDDvGfEdoD7aExt4dhw4bZiSeeGL8JPK9BoNkHoOvWrbNx48YlZVq/fr0LHHfYYYek8yV6s7i42JRH165drWXLlolmSzo9HcqwYcMGV8aoDjvuuKO1atUq6fYmejMdypAzdox5vyis4w03Jypm0uklJSWmdhfVQV/YyiNMSqcyqD21bt06zGbYxo0braysLLJDUyiDfpxpHxMmbd261dauXWtRHZpKGbp06WLZ2dlhKG3Tpk0mz6h10RTKoP1Mt27dQjmqLa1Zs8aiOtRHGRYsWGDvv/9+qO1szgs1+wBUPZItWiRn0PtB5kvUkPQFqTz8R6L5kk1PlzKojCpLmJQqhwYvQ6Z35ooX/IV1UODot4WweWg5P58wdeEv65cjTB7pUga/XYXZhlQ5pEMZouyj/M9U1PZAGf5v/yjLsMmvh7B5+Mv5f8OUIxVl8D9fYdbvtyW/HGHy0LL1UYawR0fDbFNTWoZzQJtSbbItCCCAAAIIIIBAIxAI/xOtFhuncyz//e9/V1ri8MMPr/S6ti90CHPevHnWu3dv23vvvWOLz58/34qKimKv+/Tp4w4rxSbwBAEEEEAAAQQQQKBBBeolAP3kk0/soYcesj333DO2sVECUAWZt912mx133HH28MMP23nnnWennnqqO+9GFxUdfPDBsfWcc845BKAxDZ4ggAACCCCAAAINL1AvAeiSJUvs5JNPtl/96lfVbrFO2tbFBLvuuut259Up0Dz99NOtX79+sWUfeOABGz16tPXv39+9d9FFF5muQFu2bJntsssuds8998Tm5QkCCCCAAAIIIIBAegnUWwCqHs8JEybYXnvtZYccckhsOKJHH33Upk+f7gJHXYV533332W677RZTys3NNV3F5iddXbhixQrbf//93aTu3btb27ZtbeXKlaZAVwHom2++6Q7DDxkyxL3nL6u/n3/+uX3zzTexScovPz8/9rq6J7oaTydE1zRfdctqmtahVFhYWGlb3MSA/+kiB6WGLIMcUlUG38RlWIv/0qEMOqndG4UpdF3426D20FAOqSqDLMK2Sb8MOmXGf16LpuBmlV9Dl0Fl1+ezIR2aUhn0uQjbHlLp4O9zw7TJKO3BX68+F/5zylDx/ZeuDmqzYeuqttvUlOavtwBUaApCn376aZs0aZLde++9rtfz7bffthdffNENyzNt2jSbMmWKXXbZZTZmjDfUjZeWLl1qzz33nL3xxht2xBFHuPM927VrFwtgNU+nTp1Mw/N89dVXtnjxYtczquU0vNL48eMrDYfx6quvuvy0nNKBBx5omzdvrnhRw/9B50uUTU3jjSZaLn56UyjDli1b4jcp1POoDlHK0MYFoGWB202iDYxSBj/PhnSgDL5AxV/qIjUOYQP5+NqIWheUoUITh2AO+m4nAI3/BAZ7Xi8B6N///nfr3LmzZXrD15x00kl2yimnuF7Mzz77zB1yHzt2rCutfkUsXLjQBaD+OaIKKvfbbz93sZEO0Wu4g6q/jtULojHbLr74YvdQj6iSfkGqN1TngfrphhtusKuvvtp/aSNHjjT1oiZLOj1APaDahjBJ44AqD42xF3YcUC2vpDHRwqR0KIN6svVDoSEdUlGGXK8dZ3hBaE3tJlE9+WVQXYYdD1WnrajnL2x7aEpl0I5fbSpM0r5DY+xGrYumUgbt48KOyaqgT/vmqHXRFMqgdhV2jF4Z6iLbqA5NpQzqYAo7JmtOTo476hi1Lmoqg+qLoZhqvweu8wBUgc93330X2ynpC1df3KtXr3ZfoDpkPnz48EolV7A3ePBgN+21115zvZTqqVTSh0o9Rwou/R2lgpqePXu6w/Aa/NcPQHUof9WqVW45/z+tv+qXvgLjICnofFXz8pfTX/951XmCvJZL2OX95aKUQetX8vMKUub4efzlo2yHn0eDlmHbRoUtg7+c/vrP451q8zzs8v5y6VCGqO0h6vLyjppH1OVTUQbl4derntcm+culQ3tIhzJErc8oy/s9aVHy0LJRlk9VGdQG/bZVm/aoed2pTtuWD5uHv86wywctg+/tr4+/wQSCRV7B8qp2LvX43X///TZ79mz3/qJFi1yPwwEHHGDHHHOMO2Teo0cP69u3ry1fvtwmTpxY6fC6zheN/0WtgWUHDBhgU6dOdfl98MEHrvdCPRh6rnNKlXToYObMmTZo0CD3mv8QQAABBBBAAAEE0kOgzntA9cvgd7/7nT3++OPuoQuNdBhcgaQOMZxxxhl21llnuSvg1YWt9+LT2WefHf/SPb/00kvtuuuus1deecX9utKV8kojRoxwV8Cff/757rZyugjpoIMOcu/xHwIIIIAAAggggEB6CNR5AKrN1Licjz32mLtoo2PHjpV6OM8991wXgBYUFFiHDh0CqfTq1ctdyKTz4BTE+kl533XXXa73U8Gsf4jef5+/CCCAAAIIIIAAAg0vUC8BqL+ZOpG3uqTe0KDBZ/zy8cFn/HT/HND4aTxHAAEEEEAAAQQQSA+BOj8HND02k1IggAACCCCAAAIIpIsAAWi61ATlQAABBBBAAAEEmokAAWgzqWg2EwEEEEAAAQQQSBcBAtB0qQnKgQACCCCAAAIINBMBAtBmUtFsJgIIIIAAAgggkC4CBKDpUhOUAwEEEEAAAQQQaCYCBKDNpKLZTAQQQAABBBBAIF0ECEDTpSYoBwIIIIAAAggg0EwECECbSUWzmQgggAACCCCAQLoIEICmS01QDgQQQAABBBBAoJkIEIA2k4pmMxFAAAEEEEAAgXQRIABNl5qgHAgggAACCCCAQDMRIABtJhXNZiKAAAIIIIAAAukiQACaLjVBORBAAAEEEEAAgWYiQADaTCqazUQAAQQQQAABBNJFgAA0XWqCciCAAAIIIIAAAs1EgAC0mVQ0m4kAAggggAACCKSLAAFoutQE5UAAAQQQQAABBJqJAAFoM6loNhMBBBBAAAEEEEgXAQLQdKkJyoEAAggggAACCDQTAQLQZlLRbCYCCCCAAAIIIJAuAgSg6VITlAMBBBBAAAEEEGgmAgSgzaSi2cymJZD13DPW4qknm9ZGsTUIIIAAAs1GoEWz2VI2FIEmJJBRkG9WUtKEtohNQQABBBBoTgL0gDan2mZbEUAAAQQQQACBNBAgAE2DSqAICCCAAAIIIIBAcxIgAG1Otc22IoAAAggggAACaSBAAJoGlUAREEAAAQQQQACB5iRAANqcapttRQABBBBAAAEE0kCAADQNKoEiIIAAAggggAACzUmAALQ51TbbigACCCCAAAIIpIFAsx8HtKyszIqKipJWhebJyMiocb5EmZRsG6+xuLjYlFeYFLUMW7dudauNWgZlUpNXou3zyyCP8vLyRLMlne77NWQZ/JJHLYPqIqyDK4Nn2JBlUF2o/FHL4H8+klZ8gjdLS0sbvAxy0COsg7ZBKYpD1LpoSmVIVV1onx8myZIymEX9bMpQSZ+LsHUR9XMRtAxRvtPCtLGmskyzD0D1BVrTjt8PEmqaL1Gj8AMv/fXzSjRvoulaLkhZEy3vf8FEKUP8hzHRepJNbypl8CrC9AjbHnwH/28ys0TvqS3o6zFqGfy2mWg9yaansk0mW0+y99KhDP6XXEPWRdQy+J/tKO1BeegR1iFVZYiyn/TLoM9mlO2gDNpFRvvO8utCbTJqABqlLrX/qakMel/bS6qdQLMPQLOysqx9+/ZJ1dSzoQ9ATfMlykQ9XQUFBda2bVtr2bJlotmSTk9FGfLz8yOVQduhFMVBZWjTpo21atUq6fYmejMdypCjnpEI7UE7w6gOqSqD2mSUutBON2x7iHdo3bp1oipPOl156IuKMpS4HqewDvoC3bJli/tsRqkLBW5NoQzZ2dmmR5gkSz2iOjSFMkTZP6gt+W0ySl3URxn0nZaZyRmNtf28IFZbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URQAABBBBAAAEEaitAAFpbMeZHAAEEEEAAAQQQiCRAABqJj4URaJwC5SXFlvnDaisvLm6cG0CpEUAAAQQatQABaKOuPgqPQDiB8lWrrN2f7rXyZd+Fy4ClEEixwLL8Ahv8+QKbvWFjinMmOwQQSEcBAtB0rBXKhAACCDQzga3l5bZx61Yr9v6SEECg6QsQgDb9OmYLEUAAAQQQQACBtBIgAE2r6qAwCCCAAAIIIIBA0xcgAG36dcwWIoAAAggggAACaSVAAJpW1UFhEEAAAQQQQACBpi9AANr065gtRAABBBBAAAEE0kqgRX2X5t1337VDDjnEOnToEGnV69ats3nz5lnv3r1t7733juU1f/58Kyoqir3u06eP7bDDDrHXPEEAAQQQQAABBBBoWIF67QH94IMP7LbbbrMNGzZE2moFmeeff7599dVXdt1119krr7zi8tvqDeFx7bXXuteapsfKlSsjrYuFEUAAAQQQQAABBFIrUG89oOqx/Pvf/26dO3febgs2bdpkGzdutF133dVatKhcJAWsp59+uvXr1y+23AMPPGCjR4+2/v37u/cuuugiGzZsmC1btsx22WUXu+eee2Lz8gQBBBBAAAEEEEAgvQQqR3t1VLZyb2DhMWPG2GWXXbZdcPjoo4/a9OnTXeC4du1au++++2y33XaLlSQ3N9dKSkpir9XLuWLFCtt///3dtO7du1vbtm1dT+eSJUtcPm+++aY7DD9kyBD3Xmxh78lf//pXe+2112KTunTpYmvWrIm9ru5JaWmpm1zTfNUtq2nafiX1/GZkZLjntf2vKZVBPzYa2iFKGVqVlZl5j6jtoSHLkJGTY228RqjPV04N7T9RW01Vm9QP0IZuD1HKUOa1BX3Go7aH5l6GTQUFrqnl5eWFtkxVXWzevNlyvM9ImEQZKtSak4P25f7+MEybaa7L1EsA+uKLL7reTZ37GZ9UaW+//bbp/VatWtm0adNsypQpLlBVwKq0dOlSe+655+yNN96wI444wp3v2a5du0pfWJ06dXLBnQ7JL1682PWMarlx48bZ+PHjrWvXrrHV7rHHHnbkkUfGXmuZ1q1bx15X96SwsNCtr6b5qltW09QwdV6qtjEzM9xZD+lSBm1PWIeyFcst8+knreyXF1im11MdJslBKWwZ/Lpo2bKlZWVlhSmCletHhPcIWwbtmLUdUcugoC10GVq0dNvewjPIrKH9J0JSm1bgFboMKXCgDBW10xQcWm6t+KGvo2Bh21RTcEjF/iFVDqqLqkclE+0Pqk5XGbQtYevSd2gMZdC+POyP6Kpuzel1nQegCgQVPD7yyCPbuc6aNcs17rFjx7r39KW8cOFCF4AefvjhbpoCxP322896excb6RC9goaqvzTUK5qdnW0XX3yxe6hHVEkfAPWGnnPOOe61/jvhhBPcw59wwQUXmALYZEn5q3HVNF+iPIqLi11Z2rdv74KORPMlm54OZfDdwzoUrl5lW1evttYtsiy7BvNEFlHLEF8X+kEQJuV4bUEBaMeQ26AefbV1tYeGKkNR2zam4wptvM9K2LpQj74C0LDtwXfQD8qwX1L6EasvKspQ0QMT1kH7F7XJqHWhz2fYMnjdCu7jqH152Dz8nqiwy/sO+g5ROcIk9WQrn6ZQBrWHKA76jId1UFvy22S6l0H78rCdS2HaWFNZps4D0H/84x/23Xff2UknneTMCrzDLDpn86677nJfXjpnc/jw4ZU8FewNHjzYTdPh8gMPPNA9NEEf7C1btriAzv/S0hdhz5493WF49Xb6AagO5a9atapS3rxAAAEEEEAAAQQQaFiBcMeDa1FmBZsKQmfMmOEeO++8sz3xxBN22GGH2THHHOMOmffo0cP69u1ry5cvt4kTJ1bqytZh+/hhlNQdP2DAAJs6daorha6s13mceui5zilVys/Pt5kzZ9qgQYPca/5DAAEEEEAAAQQQSA+BOu8BTbaZuiL+jDPOsLPOOit2eP2GG26otMjZZ59d6bVeXHrppbHhl9TtrSvllUaMGOEuctIQTbqgSRchHXTQQe49/kMAAQQQQAABBBBID4F6D0BfeOGFSlt+7rnnugBUh+aDDk7fq1cvmzRpkulcm/hhnTp27OgO7av3U+eK+ofoK62QFwgggAACCCCAAAINKlDvAWh1W6vD6kGDz/jl44PP+On+OaDx03iOAAIIIIAAAgggkB4CdX4OaHpsJqVAAAEEEEAAAQQQSBcBAtB0qQnKgQACCCCAAAIINBMBAtBmUtFsJgIIIIAAAgggkC4CBKDpUhOUAwEEEEAAAQQQaCYCBKDNpKLZTAQQQAABBBBAIF0ECEDTpSYoBwIIIIAAAggg0EwECECbSUWzmQgggAACCCCAQLoIEICmS01QDgQQQAABBBBAoJkIEIA2k4pmMxFAAAEEEEAAgXQRIABNl5qgHAgggAACCCCAQDMRIABtJhXNZiKAAAIIIIAAAukiQACaLjVBORBAAAEEEEAAgWYiQADaTCqazUQAAQQQQAABBNJFIHAAWlZWZm+++aYVFxe7st977712yimn2JNPPpku20I5EEAAAQQQQAABBBqBQOAA9Oabb7YTTzzRVq1aZRMmTLAbbrjBbd7ll19ukyZNagSbShERQAABBBBAAAEE0kEgcAD6yCOP2PTp061Xr172zDPP2LBhw+zVV1+1UaNG2fPPP58O20IZEEAAAQQQQAABBBqBQKAAdMOGDZabm2sDBw60goICe++99+zUU091m/fjH//Y1q1b1wg2lSIigAACCCCAAAIIpINAiyCF6NKli7Vt29ZmzZrlDsHrPNChQ4fa1q1b3eH3QYMGBcmGeRBAAAEEEEAAAQQQsEABaEZGhukc0OOPP950MdLIkSNt5513tuHDh9ucOXPs+uuvhxIBBBBAAAEEEEAAgUACgQJQ5aSLjk444QQrLCy0ww47zGV+xRVXuOft2rULtDJmQgABBBBAAAEEEEAg0DmgYlLPp66AP/DAA009ohqG6YEHHrDJkyejiAACCCCAAAIIIIBAYIHAASjDMAU2ZUYEEEAAAQQQQACBJAKBA1CGYUqiyFsIIIAAAggggAACgQUCBaAMwxTYkxkRQAABBBBAAAEEahAIdBESwzDVoMjbCCCAAAIIIIAAAoEFAgWgDMMU2JMZEUAAAQQQQAABBGoQCBSAKg+GYapBkrcRQAABBBBAAAEEAgkEOgfUz6lPnz62dOlSu/POO+3777+3Dh06WJs2bfy3+YsAAggggAACCCCAQI0CgXtAFy1a5AaiX716tRsT9KSTTrJbb73VNm/ebC+//LK7M1KNa2MGBBBAAAEEEEAAgWYvELgH9MILL7QjjjjC1qxZY7vuuquDGz9+vGVmZtrEiRObPSQACCCAAAIIIIAAAsEEAgWg+fn5NnfuXBs1apR17NgxlnP37t1Nt+OcPn16bBpPEEAAAQQQQAABBBBIJhDoEHyLFi1cT+eWLVu2y2vBggXuve3eaCQTtm7dahrnNFkqKSlxtx+tab5Eeeg2pko6XUE9xmFSOpShuLg4kkO5135aexuvdpRfg3kiIzkoRa2LnJyc0HWRWV5u5j0acxnK8/JSUhflKXDIzc11bSJRnSebrvZAGcyagkPulnxX1erwCPvZiuqgtqSU530+VI4wKVVl0OeCMpg1Bgd9n5SWloZpLs16mUABaKtWrey4446zK6+80v74xz86MH0wJkyYYLpDkq6Qb6xJwfUOO+yQtPjr1693gVdN8yXKRIGb8ujUqZO1bNky0WxJp6dDGfwvhbAOhWvX2FZvK9u1a2fZNZgnwohaBr8u1JOvdh0m5WRkmNcgrHPIbdAX1Lp169zRhIYqQ9HGDaZQPmpd6As7bHvwHXQxY+vW+mlS+7Rx40Z3Tjpl2Oi+AMM66If42rVr3YWlUepCX8Jhy7Auq+LrqG3btqHzUHuIUgbfoX379padnV37BuktsWnTJlM+YR38Muhz0djLoM94WAfVo075i+pQH2XQ90lWVlao9tKcFwoUgAro8ccft1NPPdUOO+wwF4wNGjTI/eo+88wz7fLLL2/Ohmw7AggggAACCCCAQC0EAgegPXv2tNmzZ9usWbPsyy+/dL1HBxxwgOlBQgABBBBAAAEEEEAgqEDgAFQZ6vBl7969rUePHrH8lyxZYjpcET8t9iZPEEAAAQQQQAABBOpE4IsvvrC33nrLrr322jrJvy4zDXxFzEsvveTG+uzVq5dpQPr4h66EJyGAAAIIIIAAAgjUn8Dnn39u99xzT/2tMIVrCtwDeumll9rw4cPtt7/97XYnFasHlIQAAggggAACCCCAQBCBQAGohhjQ1WiKsnfaaacg+TIPAggggAACCCCAQEQBjawwduxY++STT6xLly42ZMgQ082BMjQiy7Y0b948e/DBB90QZscee6wbo91//5tvvnHv6fodjTKhmwrpyLVGYdEoAepg1MXkjz32mH333Xem5S+66CJ3eqWf/9NPP23Tpk2zwsJC00XoI0eONI0iFCUFOgSvIQZ23313+/TTT6Osi2URQAABBBBAAAEEaiFwzjnn2Lvvvmu/+MUv7NBDD3Xne44ZMyaWg8YYP+uss+wnP/mJ7bvvvnbTTTfFDssvXbrU9t9/fxeYnnvuubbXXnvZnXfeabfccotbXsNdPfHEEy6oLSgosJNPPtkeeugh+9WvfuXGWNZMClavvvpqt+yRRx7phuM87bTTYusP+yRw+Dp69Gg3DuiKFStcMBof+apXtG/fvmHLwHIIIIAAAggggAAC1Qh8/PHH9oc//MHOO+889+4+++xTaeB7jR37/PPP20EHHeTeVy/me++958ZoX7x4sZ1xxhk2btw4d/OVs88+2435q1GN4tPQoUPtb3/7m5t08MEHmx7vv/++aQQkBaTPPvusC3I1g4JPBbJ6/5hjjonPplbPAweg6qJVlP2b3/xmuxWMGDHCJk+evN10JiCAAAIIIIAAAgiEF1BvpGKwZ555xn7+85/bKaecUqnTTzcsiB8SU4GoAkYlBZYDBw60mTNn2qJFi2zhwoX2zjvvuIvK40t0wgknxF4eeOCB1q1bN/vss8/s+++/dz2hOvyvC578pGt/dFQ8SgAa6BC8VvjDDz+Yumerezz33HN+mfiLAAIIIIAAAgggkCKBP/3pT/bqq6/a3nvv7c7l7NevX6U7UOqOdvG3+Y5/rmGadAqlzhmdM2eOOxxfXdCoEY78pHNHO3fu7G5Jq/NPdcRbd0hTvv5D54BGPfIduAfUvz2bomH1hMYnnSP6ox/9KH4SzxFAAAEEEEAAAQQiCOi255MmTbITTzzRPcrKytw5nHfddZf9/ve/rzFnzaND9ur19G8X+uGHH1Y6hK9M1EN6+OGHu/yWLVtmGuNdPan+hUonnXSS6fxPJZ03+tRTT7nhON2EkP8F7gF9/fXXXUSsQHO//far9NA94kkIIIAAAggggAACqRNo06aNPfzww67HU72ROgq9du1a1+mnQ+81pZ133tldgKTlysvLXU/qiy++aEVFRZUW1VXuc+fOdUe7b731Vttzzz3t6KOPdle8q+f1tttuswULFrir4BXUXn/99abOxygpcA+ozv08/vjj3aX3u+yyS6V1qvuXhAACCCCAAAIIIJA6AR0O10VACvjUAagLjnRIXTcHCpKuuuoq+/e//23du3c3Baw6v1NDOik/DbGpHk4lXV2vc0XVw6pD/Op09ANMHf4///zz3VX2GsZJV9XrfNSuXbsGKULCeQIFoCrkypUr7f777+dQe0JK3kAAAQQQQAABBFIrMGDAAHdVe15enusB1QVCftLQSnrEJ92W0781p3oyP/jgA1u/fr0LNjt06OBm1bifShrXU+mCCy5wV8HrFMv4/PWeekB1Jb7eUwC84447anLkFCgAVRTc27sHvM4L4FzPyOZkgAACCCCAAAII1EpAV56HvfNkkKBRvaFVg8/4Anbq1Cn+ZeTnSQNQnQ+wZcsWtxKNHaXhlm6++Wb78Y9/bC1btoytnHFAYxQ8QQABBBBAAAEEGoWADvEr6PQPxddnoZMGoOqS1Umn8UljUVVNjANaVYTXCCCAAAIIIIBAegtohCPdar0hUtIAVPcW1VVTNSX/0v6a5uN9BBBAAAEEEEAAAQSSBqD+2J/xTApI/Rvca3wqXRFFQgABBBBAAAEEEEAgqEDgcUBXrVrlLsPX4KNKOjdUQwFohH5dFUVCAAEEEEAAAQQQQCCIQOAAVIPNf/vtt7GR8DU46gMPPOBuCzV16tQg62IeBBBAAAEEEEAAAQQs6SF436e4uNjeeustd0FSz5493WTdD/Sss86y3NxcmzBhgv3Xf/2XPzt/EUAAAQQQQAABBBBIKBCoB1TnfJaUlLjB6KvmpEHqN2zYUHUyrxFAAAEEEEAAAQQQqFYgUACqMT8HDx7s7kW6fPnyWEaffvqpOwd06NChsWk8QQABBBBAAAEEEEAgmUCgAFQZjB8/3t2yabfddjONhq9zQP17h+peoyQEEEAAgdoLbPKOLk1as85WFxbVfmGWQAABBBqpQKBzQLVtO+ywg82aNcsWL15s//rXv0zngP7kJz+x/fbbr5FuOsVGAAEEGl5gbVGxjVm+0vbfqZv16tSx4QtECRBAAIF6EEgagM6ZM8fdd7Rv3772/vvvx4Zb0q03lTQ0kx7du3e3fv361UNxWQUCCCCAAAIIIIBAYxdIGoBeeOGFtv/++7ur3E855RTbvHlztdvLrTirZWEiAggggAACCCCAQDUCSQPQ+fPnx+56tHr1anfYvZo8Ek6vbl6mIYAAAggggAACCKS3gE63nDt3riukbrneu3dvGzBggDsynoqSJ70ISVe/t2hREaMedNBB9uabb1qrVq22e/jzpKJA5IEAAggggAACCCBQO4GvvvrKli5dWruFksz9xhtv2L333mvqjPz4449t1KhRdthhh6Vs6M2kAahfroKCAvvPf/5jZWVl/iT+IoAAAggggAACCDSwQFFRkf385z+3vffe2/bYYw/71a9+ZeXl5SkplXo8H3nkEfvb3/7mrgXSNUDTpk1LSd5JD8H7a9CQS2PGjLHrrrvODUa/1157uWGY/Pe7du1q++67r/+SvwgggAACCCCAAAL1IKDboqu30k9PP/20DRkyxM455xx/Ukr+6jqgNWvWmGLAVKRAAahWdMcdd7iLkC677LLt1stFSNuRMAEBBBBAAAEEEKhzgYULF263juqmbTdTgAlTpkxxvapbt251wecvfvELO+KIIwIsWfMsgQPQlStXJuzSDXIOqKLmzz77zHUR77777jWXrIY51q1bZ/PmzXMnxarb2U86V0Hd0X7q06ePG8PUf81fBBBAAAEEEECgqQiot1O9nvFJ01KRlM+f/vQndwqm4sCrr77aHRG/4YYbImcf6BxQraVdu3buyqf27dtv9zc7OztpQXS+wLXXXmsrVqywW265xV5//fWk89f0poLM888/33TCrU4LeOWVV9wiitC1Hr32HwIjIYAAAggggAACTVFAh9p1lLpLly6mczQffvhhGzRoUEo2VbFfr169TB2HRx11lF1xxRX20ksvpSTvwD2gYdemE2FnzJjhcHQJf//+/e0vf/mLDRs2LJblpk2bbOPGjbbrrrvGrrr337ztttvs9NNPrzTQvc53GD16tMtL71100UUuv2XLltkuu+xi99xzj784fxFAAAEEEEAAgSYtoFhJj7pMGzZssBdffLFSPBZlfXUegGZkZNiDDz7oylji3fP4o48+cofN/UI/+uijNn36dBc4rl271u677z7T/eb9lJuba1rOT+rlVE+qBshX0l2Y2rZt6y6OWrJkictHw0XpMLy6jvVefPryyy9t+fLlsUnKr7CwMPa6uie6+l/bUdN81S2raVqHkspUWlrqntf2v3Qog8oeyWFbPQYxT+Tj+0Wti+Li4tCjOrhrC73/Gr4M5eHLUFzxmdrq1UnY7VCb1A/MsMv7nwvVRdgrNtUeopTBb08NWQZ//xalLtLFQW0ibHtQHSjJI2weWn+UMvjtwa+TRPuhZNOVR1Mpg18nybY30XtR26QMlRpDGaLsPxL5pcv0Z5991t2MSOXRLdkHDhxoY8eOTUnxkgag6kk877zzXJCnoZh0NXzYlJOTY2effbYpn3Hjxrls1Ov59ttvu4ha44vqUL1OeNWFTrrqXkljWj333HPuCi+d+KrzPdUlrEDIT506dXLjUumQvO5Vr15WLaf1jB8/3nSVvp8mT57s8vNfH3jgga731X+d7K/KGyUpmI6aGnMZMvPzrZ0HsGXLFiuLaNmQDm20YywvC9xuEtV5lPZQUYby0GXIzN/i6iLfq5PSBq6LvLy8RESBp0dtDw1ZhryCih/A2jeG3Y4l3rLFZeXWd9uP3cBwVWZsUIfCinP3FXyGdfA3J+ryDengb0M6lEH7aj2ipKh10RjKoPjG//ESxSrdlr3xxhtNj7pKSQPQ22+/3X7605+6ALRHjx727bffWufOnUOVpWPHjjZ16lT74IMP7De/+Y29+uqrNmvWLHfI3Y+mtePRlVsKQA8//HC3HgWV++23n+s11SF6jcZftaLVk6LzUC+++GL38Hs91eOo3tD4oQiuvPJKt35/I66//np3zoT/urq/+gAp4A277fp1pNMMdH6GBvcPk7S8Utgy6Be9tqMhy1C8aaOp/1dtoZV3nkqYlA4OeZmZluH1/OlcmzApFXWhMni3IAtdhuK8XFcXOqe7dcjtUF2o91FtKkzS51aHdNSm9QM0TNKwIOopacxlWL+p4hbHqouwbeqmufNstbefmXZUuKtT06EuNm/OcU2gnXfUKqyD2oO+H9RTEyb5DurUaN26dZgsTMGI8glbBpV//fr1Rhkaj4OO3io2IdVOIGkA2q9fPxesHXvsse6QyM0331zth1I9jhr4tLqk4EtXvyugVBB3zDHH2F//+ldbsGCB+/LSOZvDhw+vtKjmGzx4sJv22muvmXop9VDSB1u/iBRc+jsIfYn17NnTHYZXb6cfgOpQ/qpVq9xy/n8dOnQwPfyU6X2J19RwVB49aprPz7PqX385/fWfV50nyOsoZfCD9ihl0PqVwm5DhoImL0XZjqhl8B2C1LsrbDX/+X3vYR38Q0sNWQatWz8GMiO0yah1kRKHiJ/NdCiD6kJJn4+wbcq2Ncqwy/unQERqkxH3D2qLSlHbZJT9S6ocKEPFfl71GbZNalmlhmyTFSWouQwqo78/9Jfhb80CFXu+BPPp0PchhxzirjbXF/eiRYtc4KjgMf6hczITJfX46TxP/36iOkSuX3e6qkrBqF6rd7Vv377u3MyJEydWqkitP/6XpIZ80sj86k1VUo+qej/00HOtS0mHFmfOnJmyK8FcpvyHAAIIIIAAAgggEFkgaQ+ozrd86qmn3ErUA6nzM3X4tDZJvwp+97vfucDw8ccfd72WGi6gW7duLpszzjjDzjrrLHcFvH4pVR1bSueNVk2XXnppbPgl/fLwr/zSgPg6b1VDNKlLXBch6R72JAQQQAABBBBAAIH0EUgagMYXU2Nv6pwvjS+l8zJ33nlnd1hcY03VdP7WAQcc4AJQnVSt85zi07nnnusCUJ2AH39oPH6eqs/Vezpp0iRXnvhzIhUc33XXXa73U8Gsf4i+6vK8RgABBBBAAAEEEGg4gcAB6BdffGHHHXec/fDDD24IJPUw6vzKoUOHukHfaxqMXptYNfj0N1uH1YMGn/4y+hsffMZP988BjZ/GcwQQQAABBBBAAIH0EEh6Dmh8EX/961+7+39qDM3PP//cXfCji4s0ruaf//zn+Fl5jgACCCCAAAIIIIBAQoFAAagu6Pn000/d4W1dta6kczt1XuhVV13lLvZJuAbeQAABBBBAAAEEEEAgTiBQAKoLfTQ8hQLRqklDImloJBICCCCAAAIIIIAAAkEEAgWgOr9z4MCBpkHbP/nkk9it79544w13m01dbU5CAAEEEEAAAQQQQCCIQKAAVBlpfE1dgHTYYYe5OyNpbM6f//znbpzQq6++Osi6mAcBBBBAAAEEEEAAAQt8Ffxee+1l8+bNs3feecddeKReUQ2vpFt1khBAAAEEEEAAAQQQCCoQOABVhhpXc9iwYe4RdAXMhwACCCCAAAIIIIBAvECtAtD4BXmOAAIIIIAAAgggkB4CX3/9tRsfvWvXrikpkG65/tFHH7m8dHOfHXfc0d1CXbc+T0UKfA5oKlZGHggggAACCCCAAAKpF7jyyivtlltuSVnGM2fOtDFjxpjuhPnPf/7THnnkEdtjjz1s2rRpKVkHPaApYSQTBBBAAAEEEECgYQTeeustFxhq2Mzf/va31r9//5QURNf6KPD00wsvvGAXXHCBLVq0yPWI+tPD/K1VD6ju1/7888/bqFGj7Pvvv3eD05eVlYVZL8sggAACCCCAAAIIRBTQWOzq/VRSTPa73/0uYo6JFx8xYoS1bNnSPvzww8QzBXwncACqaHffffe18847z0aPHu2GZLr11lvtqKOOstWrVwdcHbMhgAACCCCAAAIIpErgr3/9q+uR9PN777337KWXXvJfpvzvIYccYosXL46cb+AA9MILL3T3gl+zZo3tuuuubsXjx483dfdOnDgxckHIAAEEEEAAAQQQQCC4wPr16+2OO+7YboFrrrnGCgsLt5ueigm6K2b79u0jZxXoHFCtbO7cufbUU09Zx44dYyvt3r27XXHFFfb444/Hun9jb/IEAQQQQAABBBBAoM4EvvvuO7vxxhurzX/ZsmXWp0+fat8LO1G3X//Xv/5lt99+e9gsYssFCkBbtGjhejq14qpJl+mrF5SEAAIIIIAAAgggUH8CBx10kOlR16m0tNRWrFhhN998swtqdfpl1BQocmzVqpUdd9xxrpdT94JXUq/ohAkT3NVRQ4cOjVoOlkcAAQQQQAABBBBII4FXXnnFNAaobkR0+OGHmzokp06dmpISBuoB1Zp0mP3UU09194LPyMiwQYMGWUlJiZ155pl2+eWXp6QwZIIAAggggAACCCDQ8AIjR440PeoqBQ5Ae/bsabNnz7ZZs2a5e8GrV1TjQ+lBQgABBBBAAAEEEEAgqEDgAFQZqufz6KOPdo+gK2A+BBBAAAEEEEAAAQTiBQKdA6oFhgwZYnl5efHLuucaiukXv/jFdtOZgAACCCCAAAIIIIBAdQJJe0DnzJljb7/9tltOo97rnqDZ2dmxfHRV1JQpU2yvvfaKTeMJAggggAACCCCAAALJBJIGoHvuuaddddVVVlRU5C44ev31193VUH6Guh1T79697aabbvIn8RcBBBBAAAEEEEAAgaQCSQPQHXfc0T766COXwcknn+yGXUrF6PdJS8SbCCCAAAIIIIAAAk1aIGkAGr/lGvepoKDADUSqG98r6RD85s2bbd26dW6c0Pj5eY4AAggggAACCCCAQHUCgQPQZ5991i655BKr7m5IF198MQFodbpMQwABBBBAAAEEENhOIPBV8Ndee62ddtpp9s4771iHDh3cmKAPPvig9ejRw/7whz9slzETEEAAAQQQQAABBBCoTiBQD6gOs69evdpGjx5tu+yyi3Xr1s06d+7sRsjXBUp333233XfffdXlzzQEEEAAAQQQQAABBCoJBOoBbdu2remKd38Ipn322Sd2cdKAAQNMwzWREEAAAQQQQAABBBAIIhAoAFXw2b9/f7v99tstNzfX3X7zhRdecEMzTZ8+3Xbfffcg62IeBBBAAAEEEEAAAQQs0CF4OT388MN20kkn2cCBA00XHR188MGmIZl0JbyukCchgAACCCCAAAIIIBBEIHAAeuihh9qyZcusuLjYBZ7z58+3GTNmuFt09urVK8i6mAcBBBBAAAEEEEAAgeA9oLIqLy83BZ6FhYWOToHnV1995cYC3X///Rslp7appKQkadk1j1JN8yXKxB831f+baL5k09OiDMuXuSKWeKMghEnqLVfS37CWZWVlLo+wy/t1oL8ZGRkur9r+V9EaUtMeGqoMqagLtckgn59Evn5dRG0PqSiDypKZGeiMpO02R21Sj7BtsrT0/8ZVDpuH20V5DTPs8n5dRHWIUhepcYjWJlPxuVBbiOaQmv1kKsqg9hC2TaXKoTGUQWWUN6l2AoF7QP/85z/brbfe6s4BrbqKESNG2OTJk6tObhSv9SHxA+pEBdY8SjXNl2h5f6emEQPUUMOkdChDi9dfM8vItMI9fhxmE6zUC/TV4EpKtlrZth8xtc0oVQ7qyffrpbZl8PY0+jUWuT1EKYN2dhlRyuBtf0VdlISuC98v6uciikMqy+C3rdq2By2nR1gH/wt+q/f5CJtHxZdf+Dbpb7vqwn9e3w5at5I8wjqoPUSpC3/bozg0pTKoLsIGVnLQsmHr0q+LxlAGtZewTrX9nDWl+QMFoGoIY8eOdeN9/vKXv7R27dpVMgjbi1MpkwZ6kZWV5cY1TbZ6NS5to8Y/DZO0vO4iJTdd0BUmpUMZctRjmBneoTA72xR+Z2e3tuyQlv6XddS60MgOrVq1ClMV5hwitAdtg9pDQ5ahqE0bU7+/RraIUhfa6YatC9+hjVeW1q1bh6oL/aDT/ilqGVQXDVWG7K0VPV6tvboIux2Z3ufS20mFXl6O+fn5rk1GcVDQEXYb2pRV9CCpTYbNQ9sRpQy+g9qkP+pLbRum1q98omyD6qIplEGf8bAOckyFQ32UQfuPsEdQatu+mtL8gQJQBT+63ebw4cNDN6amhMa2IIAAAggggAACCIQXCHTSk34Jnn322fanP/3J/SIJvzqWRAABBBBAAAEEEGjuAoF6QIV02223Wd++fd1wTLrgKL67efDgwe4uSc0dk+1HAAEEEEAAgegCBd4h+Dc3bLRBbdpab68TjNT0BAIHoCeffLK77/vxxx9vXbp0qSTRr1+/Sq95gQACCCCAAAIIhBXYWFxiNy5dZo936Gi9O3cKmw3LpbFAoAA0Ly/PvvjiC1u4cKHtu+++abw5FA0BBBBAAAEEEEAg3QUCnQOqOx5pzE9duUtCAAEEEEAAAQQQQCCKQKAeUK3gjjvusP/+7/+2a665xt37XUNE+GmnnXZy54f6r/mLAAIIIIAAAggggEAigcAB6BVXXOHueHTZZZdtl1djHoh+u41hAgIIIIAAAggggECdCgQOQH/44YeEI/1rMHcSAggggAACCCCAAAJBBJIGoHPmzDGd/6nhl2bPnp3wNpLdu3c3roQPws08CCCAAAIIIIAAAkkD0AsvvNA05ueECRPslFNOcYfgqyPjEHx1KkxDAAEEEEAAAQQQqE4gaQA6f/58dw90LbhmzZrqlnfT4gelTzgTbyCAAAIIIIAAAggg4AkkHYapZcuW1qJFRYw6bNgw0z3hW7VqVemh3tFf/vKXYCKAAAIIIIAAAgggEEggaQ+ozgF9++23XUYffvihjRkzxnRfeD+VerfKmjJliu21117+JP4igAACjUagbNX31n70HVZ2+ZVm/X7SaMpNQRFAAIHGLpA0AN1zzz3tqquusqKiIispKbHXX3/d4q94Vw9p79697aabbmrsDpQfAQSao0BZuWV4+zcrK2uOW882I4AAAg0mkDQA3XHHHe2jjz5yhdO94HW4XVfFkxBAAAEEEEAAAQQQCCuQNACNz3Tq1KnxL3mOAAIIIIAAAggggEAogaQXIcXnWOYdonrzzTfdhUiafu+997qhmZ588sn42XiOAAIIIIAAAggggEBSgcAB6M0332wnnniirVq1yh2Kv+GGG1zGl19+uU2aNCnpSngTAQQQQAABBBBAAAFfIHAA+sgjj9j06dOtV69e9swzz5iGZXr11Vdt1KhR9vzzz/v58RcBBBBAAAEEEEAAgaQCgQLQDRs2WG5urg0cONAKCgrsvffes1NPPdVl/OMf/9jWrVuXdCW8iQACCCCAAAIIIFC/Ap999pndf//99bvSgGsLFIB26dLF2rZta7NmzbKXXnrJnQc6dOhQd294HX4fNGhQwNUxGwIIIIAAAggggEB9CMybNy9tA9BAV8FnZGSYzgE9/vjjveHyymzkyJG288472/Dhw02D1V9//fX14cg6EEAAAQQQQAABBJqAQKAAVNupi45OOOEEKywstMMOO8xt+hVXXOGet2vXrglQsAkIIFCfAuU//GBtH3nIys+/0GxP7qZWn/asCwEEGpfAJ598YhMnTrSvv/7ahgwZYqeffrp1797dbcQP3r5UIxN9/vnnbto555zjOgyr20LdwXLcuHH21ltvmZ7r1Ep1KurGQkoPPvig9enTx2bMmGHK97bbbrO99967uqwiTwt0CN5fiwq1dOlSu/POO+3777+3Dh06WJs2bfy3+YsAAggEFigvLrasFcut3DuvnIQAAgggUL2AjjQfe+yx9s0337jrb15++WX77//+bzfzxo0b7aCDDnIXieuGQTpKfdJJJ5kuHK8uXXDBBa5DUbdQP+SQQ9wt1tW5WF5e7mbXcJu//vWv7dNPP7W8vLw6vflQ4B7QRYsWuR7Q1atXxzbw1ltvtc2bN5swdEiehAACCCCAAAIIIJA6gWuuucZ++ctf2kMPPeQyVYCpHtAvv/zS/v73v7uLxNU52KpVK7vsssvsRz/6kQsyzzvvvEqFUC/q008/7UYwUrCqpOBTR7U1qpFOq1RSx+K7775b6dbr7o0U/xe4B/TCCy+0I444wtasWWO77rqrK8b48eMtMzPTdQunuFxkhwACCCCAAAIINGsB9Uz+61//cofdfYiuXbvazJkzbZ999jFd5f6zn/3MBZ/++wpQc3JybPHixf4k93f+/PnWunVr15vqv6FeUHUgKjj108EHH1znwafWFSgAzc/Pt7lz57oxPzt27OiX0Z1roPNANT4oCQEEEEAAAQQQQCB1Alu2bHGHwhNda6Oj0OrxjE/+uaE6xzM+bdq0yTp37mzxeeki85122smdD+rPu+OOO/pP6/RvoAC0RYsWrqdTEFXTggUL3HtVp/MaAQQQQAABBBBAILxA+/btXYAY35up8zxPO+00e//9923PPfd0t0mPX4PO41Tc1q9fv/jJbl5dWKQeVT/p7pZffPGFHXjggf6kevsbKADVeQXHHXecXXnllbFuWvWKTpgwwZ3oqjFBSQgggAACCCCAAAKpFbj44ovdVe66Mr3Yu3jzL3/5i3344Yd26KGH2iWXXOKujB87dqw7F/SDDz6wxx57zHSOpw63xyed76m7WerK9iVLltiKFSvcMJrqAT366KPjZ62X54EvQnr88cfd1Vc6WVVdthp8vqSkxM4880zT/eBJCCCAAAIIIIAAAqkV0Djsa9eutZ///OduuCRd9f7kk0+6GwQdc8wx9re//c10oZIuDFfP5ymnnOKmVS2FLi567bXXTBcn6fxRDb2kXtJ//OMf1qNHj6qz1/nrwAFoz549bfbs2e5uSLrySr2iBxxwgHvUeSlZAQIIIIAAAggg0AwFFDiqV1NjdOo8Tv8cT59CQyudf/75rkdTFxT5Y3rqffWe6uGnn/zkJ6a7I+kW6+pM1J0u41N9XtMTOABVAVVYddM2RFdtPBDPEUAAASfgHYXxxoUDAwEEEGjyAjqkXjX49Dda8Zk/QpE/LdnfHXbYIdnb9fJerQLQKCXSYKmKuvv27ZuSrt5169a5/Hr37l1plH4NM1BUVBQrqgbPTwfoWIF4ggACKRPIema8ZeniyNvuSFmeZIQAAgggUPcCgS5CiloMDXCq80Q1UOodd9xhDzzwQKQsFWSqu/mrr76y6667zl555RWX39atW+3aa691rzVNj5UrV0ZaFwsjgAACCCCAAAIIpFYgcA+oBjWNHwM0aDE0DtUzzzxjukJr9913t7PPPtuN4P+rX/0qdu6BzmlQD6m6j3UCbXzS1Voa8T9+OAEFsKNHj7b+/fu79y666CIbNmyYLVu2zHbZZRe755574rPgOQIIIIAAAggggEAaCVSO9pIUTIeyde6nrp46/vjjA4+Sn5WVZU899VRs4NPCwkI3qKo/QOqjjz7qBrJX4KirvO677z7bbbfdYiXJzc11V9v7E9TLqaED9t9/fzdJ50O0bdvW9XRqWAHlozGwdBh+yJAh7j1/Wf194oknKo2ZpYupdDg/WdI6lWqaL1EeGrNLSYG2ztMIk9KhDC22bUdYB2+MCMv2Nl73l82rwTyRUSoddBevMKlFmXfPXO/uFGEd/Hvuqj00VBlideHVSUPVhV8GjS+8JWR7cG0yQl1Ybo5rk1HKELVN5npD2impDGHbVGlpmbuXc9jl/TapQa3DtsmoDjkFBZEdopbBd1CHi/ZTYRJlqFCTgzzDtslNhRWn0uUX5IfOI2oZgrYH7cv9mCZMm2muywQOQF944QUXSJ511lkuqDvnnHNcMKpzOmtK/qj7CsT+/Oc/m8YN1a2k1Ov59ttv24svvuiuqp82bZpNmTLF3ct0zJgxLlsdtn/uuefsjTfecLcC3XvvvV0wGx/IderUyV3RpUPyGqxVPaNabty4cabbhWpdftLzPfbYw3/pAteqva6xN7c98RtWTfNVXc5/reX1UDAeducetQyyj1oG7zI0t0lhHcq97VeSQ0aVnm73RoD/UuWgbQhbF9sYtuutD1B8N4vqQjtGOegRKnlVodqIWheZ3vozG6guyrMqfgCoHsKWQXaRHDIr/KOUQfWpL6qwdZEZV4aweWh/GMUhFW0yHRxUBj3COqbKgTLo2sBoddGiRUXHT5a3f4hSn1HqQp/rIPvq0PvxUDv/prNQ4AD0//2//2d6aABUndP57LPPmu4Xqkv6z/N6RRWQKhBMlNQjOWrUKLej1phWSrNmzXINS4fnldQ7unDhQheAHn744W6agsr99tvPdLGRDtGrov0gxM3g/acGkp2dHRtuQD2iSlqnekNVNj8NHz7c9PCThi/QramSpfXr17uey5rmS5SHBo5VHh06dKg0PEKi+aubnooyyCNKGXIyva84b2fQsQav6sqvaWHl7PUAAEAASURBVIVevWiXoiElskPmoaEjlKLUhRx0dwn1fodJOerF9h5hHTR+rl8XUcvQKaRj0fp15l0/7n5MRqkL7aDD1kWRV5cqg9pDm5DbkaNebK8uQjt4PRdRy6Af0vqSC+vQzutQV5JD2Dwy9dn0HMIur32ojkDpc1F18OqK0tX8vxy0bw5bhvYZFT9IojhELYPvoE4TfaeESeoNUz5hHZpSGbSvC+uQm1dx58XWrbND56G6iFIGtWfFJTW1B32vEoTW/tMSOAD1s9bOQYPPqxextxcUamwqXQh0/fXXuxH5//CHP2wXZOmuSXpf9yvVRUJ+RenLS4fM4wNCrUe/5gcPHuxWqUFTdYso/zZR+nDqUJW+wP0dpYISjVOqC47Uw+kHoDqUr9tMkRBAAAEEEEAAAQTSR6DiJ2fA8nz99df2+9//3vbaay878sgj7dtvv7Xnn3/eHUrXPUl1+FzvV0233367GyrphhtuiAWfmkcj+OuQuUbg16H85cuX28SJE10A6udxyCGHVBpGSV3xAwYMsKlTp7pZdNspDaSqh57rnFIlBb0zZ850d2xyE/gPAQQQQAABBBBAIC0EAveAqkfy3XfftX333dcd6j733HMrjeepw/Gnnnqq/fvf/660YYsWLXJ3UNJdlCZPnhx776GHHnIXEp1xxhmm80r9w+sKUuOTrpqvmi699NLY8Es6d0tXyiuNGDHCXQGvIZp0OEkXIemWVSQEEEAAAQQQQACB9BEIHIAqkNPhdfU+Jkoa69M//O3Po4BV53omSgpkFYAWeFdA6jyKIKlXr142adIkd1V5/PklGibqrrvucr2fOszvH6IPkifzIIAAAggggAACCNSPQOAA9N5773VBooZA0nmYSjpBV8N2aJiF4447rla3gYrfPB1WDxp8xi8XH3zGT68aBMe/x3MEEEAAAQQQQACBhhUIHIDqqvdLLrnEXQBUtci60b0CUBICCCCAAAIIILDSG8czr7jIukGBQAKBwBch6er10047zd555x3XW6lzOh988EF3HqgOzZMQQAABBBBAAAEJPLx8hV3/9VIwEEgoEKgHVIfZV69e7W5/qWGTunXr5sblGjlypBsO6e6773Z3MEq4Ft5AAAEEEEAAAQQQaFQCGgdVNwzSBd+6sDvs2NXVbXSgHlCdU9myZcvYwLz77LOPffTRRy4/XZQ0Z86c6vJmGgIIIIAAAggggEAdC5R5nYTF06Za8RuvW7l3i+VUJI25rtue626VOtI9bNgwdzOhVOStPAIFoAo+dXtLjeepe7MfcMABpltz6g4D06dPt9133z1V5SEfBBBAAAEEEEAAgYACpYu/tPzrr7bil1+04hcn25bLLrGylSsCLp14tvvvv9/dOv2pp56yDz/80PLy8uytt95KvEAt3wl0CF55Pvzww3bSSSfZwIED3TigGvdTt23TlfD+oPC1XDezI4AAAggggAACCNQgUO7d0rvcOx2yair3LvQquPvOislePOan/PvHWpvrbrSMzCx/Uuxvhnfjngxv9KGa0ueff27xY7EPGjTIjes+dOjQmhYN9H7NJdiWzaGHHmrLli0z3ddcgef8+fNtxowZ7pwAjctJQgABBBBAAAEEEEi9QOmSr6zwj7W44NsbHrPguqurLUjbP/zRMnr+qNr34ifqbpc77rhjbNIOO+xguiNmqlLgAPTVV19192f3x+vUfdYvuuiiVJWDfBBAAAEEEEAAAQSqEcjarZdlX3nNdu+UexcJFT3xmHnnRG73XuuRv6u2pzNjh/8LKrdbKG6CTr/0x33XZJ12qQ7IVKXAAaiGYfruu+/s2GOPteHDh9vJJ59sO++8c6rKQT4IIIAAAggggAAC1QhkeHeKbHHAgdW8Y1aev8WKn3ry/97zDq+3vuIqa7l///+bFuJZz5493QhI/qIaDalPnz7+y8h/A12EpLUsXrzYPv74Y3crznHjxpmGYzryyCPtj3/8o33zzTeRC0IGCCCAAAIIIIAAArUTaDX4Z9bmxlss65BDLWvAEe551OBTJVBnoy5Ays/Pt++//95ef/1103mgqUqBe0AzMjJMFx7poavhP/nkE7v66qvt+uuvt08//dQmT56cqjKRDwIIIIAAAggggEBAgax99rU23iOV6cwzz3QXmavXMysry6666irbb7/9UraKwAHo2rVr7d1337WZM2e6h05E1fhQCkJ1hyQSAggggAACCCCAQNMQ0DmgGnJz06ZN7tzPFgGunK/NlgcOQBUB5+Tk2H/913/ZqFGj3AVJO+20U23WxbwIIIAAAggggAACjUigc+fOdVLawAHozTff7I7/v/baa7ZkyRJ32F0XJB199NHWrl27OikcmSKAAAIIIIAAAgg0PYHAFyFdc8017hD8+vXr7a677nID0N9www2mcaF0HigJAQQQQAABBBBAAIEgAoEDUD8zjQlVVFTkrorSIXmdI+CPDerPw18EEEAAAQQQQAABBBIJBD4ErxvRT5s2zebMmWM691O35fzrX//qzgXNzs5OlD/TEUAAAQQQQAABBBCoJBA4AJ0+fbob/+mBBx6wQw45xDQsEwkBBBBAAAEEEEAAgdoKBA5AZ82aZQUFBaZzQHVHJKVS78b3mzdvtnXePUePO+642q6b+RFAAAEEEEAAAQSaoUDgAPTZZ5+1Sy65xLZs2bId08UXX0wAup0KExBAAAEEEEAAAQSqEwh8EZLuBa8B59955x130dHs2bPtwQcftB49epjODyUhgAACCCCAAAIIIBBEIFAPqA6z6yb0o0ePdveA79atm2lg0pEjR7or4u+++2677777gqyPeRBAAAEEEEAAAQSauUCgHtC2bdu64Zb8q9332Wcf++ijjxzdgAED3JXxzdyRzUcAAQQQQAABBBAIKBAoANVYn/3797fbb7/dcnNz7YADDnD3By0pKTFdHb/77rsHXB2zIYAAAggggAACCDR3gUCH4IX08MMPu7E/Bw4caLro6OCDD3Y3p9eV8FOnTm3ujmw/AggggAACCCCAQECBwAHooYceasuWLbPi4mIXeM6fP99mzJhhQ4YMsS5dugRcHbMhgAACCCCAAAIINAYBxXz/+Mc/XNx31FFHpXQM+ECH4IV0zz33WKtWrVwh9Hq33Xaz8847z5566in77W9/q0kkBBBAAAEEEEAAgXoWWOmN0/7E0u/syW+X2abikpSsXWO+77nnnvb666/buHHjbN9993Xjwackcy+TwAHoQw89ZHfccUdsvV988YUddthhNnbsWBs2bFhsOk8QQAABBBBAAAEE6kdg/qbNdvA/3rfRixbbqIVf2j4z/mFLqxmzvbal+fOf/2wXXnihKf57+umn3bVAEyZMqG02CecPfAj+tddes5/97GfWokULKy8vtzvvvNOOPfZYmzJliusNTbgG3kAAAQQQQAABBBAILVBSVmabS7Zut3yBdx3OCR/+000v9Obx0y/mzLNXjxxgmdXcNr1Lq5aWVc10f1n/r8Z4j7/tuu56mZeX578d+W/gAFRXvs+cOdMFnfn5+fa3v/3NzjnnnMgFIAMEEEAAAQQQQACBxAL/XL/BTp/zaeIZqryz1IvT9n/n3SpTK15+cMxR1qdD+2rfi5/YunXr2MvJkyfb119/7U69jE2M+CRpADpnzpztot1bbrnFrr76anc/eJ2YqtS9e3fr169fxKKwOAIIIIAAAggggEBVgX07drDHDupfdbLlbd1qN/7vQiv2jkxXTQ8d8BNrmbn9mZY922RXnTXpa53/qd7Qt956yzp16pR03tq8mTQA1bH/BQsWVJufAlE/jRgxwhQdN8a01au8jRs3Ji265lGqab5EmZRt6xbPycmxzGoaQ6Ll4qenQxkyytTAy0I7lG/Jt1ZeDupBL6jBPH7b459r7FmlqHWh8WzD1kWGPujeo6HLoHKELUO5d35QQ9dF+ZY8V4YC7+T5wpDtIcP7bEVz2FYGr02GLYOuEtVpSWHrIi9vi2vTBV4ZwuahfUyUMvj7KH0u9PkMkyI7ePsHJa0/rEPUMvgOOsyodhkmNYUyqC0pRXEoLVWbDL+vzi0scmUoLCwI3R70faE6Dduegjroc6MhKesydfN6I0/p2aPaVeR4h+bv8M7/9FMr7/D6w16wemKPnf1Jof8q8HzmmWfsvffeS/nplkkDUA215FdAstKH/SJPlmd9vadzWnVb0WRpw4YN7jyImuZLlId2SMqjQ4cO7o5SieZLNj0dypCbmeFdtpZpHWrwSrQdhW3bmD6iurNW65B5yEEpbF1oh7R+/Xo3moNGdQiTcnXujPcI65DKMoR1KPIM9LOqTZs2lh2yLrRT1/4hdBk2bohchtwM79e9Vxehy7BpkytDtufQJqTDJi8PffmELUN789rTtroIm4f2wTpXK+zy+oGr87vat29v8YfdXMEC/hfZQXXpJbXJsNsRtQzp4JCqMiifsI5qz2vXrrV27dqZfwfEgM0gNltWltpk+H117raLaFpnZ4feDt1GXPvbunbQ56Yh46Df/nh329s7pP7YN99aK29fcMkeve2nXXeM1UXYJ+PHj7dJkya5O1/WxXCbSQNQ3QGpOaT4k2yTbW/Q+arm4S+nv/7zqvMEfR12eX+5dCiDttUvT9Dt9ufzl/P/+tNr+zcdHBq2DBViDVqGbYGXShK6Pitit9DL++uN6hB1eVcbzXz/4FXiNoaG309GaZPxbcptUC3/85ePWoZUtMlU5VFLAje71wpif+NNQuW1rW3Vdll/vTU51PR+bdcbZv7BO3UzPVKZfv/737vx37t27RrL9rLLLjNdHZ+KlDQArboCHZJQ75F+WSnpV5J+YeiX83HHHVd1dl4jgAACCCCAAAIINEKBb7/9tk5LHTgAffbZZ+2SSy6xLdWMLaVbcxKA1mk9kTkCCCCAAAIIINBkBLa/PCrBpl177bV22mmn2TvvvOPOZZw9e7Y9+OCD1qNHD3d1VILFmIwAAggggAACCCCAQCWBQD2gOsy+evVqGz16tO2yyy7WrVs3d1LvyJEjraioyO6++2677777KmXMCwQQQAABBBBAAAEEqhMI1AOqq5Z1QZJ/Ndw+++zjropShgMGDDCNF0pCAAEEEEAAAQQQQCCIQKAAVMFn//797fbbbzeNd6W7Ir3wwgtueIPp06fb7rvvHmRdzIMAAggggAACCCCAgAU6BC+nhx9+2E466SQbOHCg6aKjgw8+2I0Zpyvhp06dCiUCCCCAAAIIIIAAAoEEAgeghx56qBsPSoOqa9BVDVI/Y8YMGzJkiPXq1SvQypgJAQQQQAABBBBAAIFAh+B9JvV2Tps2zUaNGmW6g5AOxe+6667+2/xFAAEEEEAAAQQQQKBGgcA9oIsWLbITTjjBXQ2ve6vqcPytt97qBqJ/+eWXbeedo99ztMbSMgMCCCCAAAIIIIBAoxcI3AN64YUX2hFHHGFr1qyJ9XrqPqG6/+nEiRMbPQQbgAACCCCAAAIIIFA/AoEC0Pz8fJs7d6479N6xY8dYybp3725XXHGF6Up4EgIIIIAAAggggAACQQQCBaA631M9ndXdhnPBggXuvSArYx4EEEAAAQQQQAABBAIFoK1atXL3er/yyivtk08+cWrqFZ0wYYI98sgjNnToUCQRQAABBBBAAAEEEAgkEPgipMcff9xOPfVUO+ywwywjI8MGDRrkBqI/88wz7fLLLw+0MmZCAAEEEEAAAQQQQCBwAKqr3GfPnm2zZs2yL7/80tQrqmGY9CAhgAACCCCAAAIIIBBUIHAA2q9fPxszZoydfPLJdvTRRwfNn/kQQAABBBBAAAEEEKgkEOgc0IKCAvvPf/5jGv+ThAACCCCAAAIIIIBAFIFAPaBt2rRxvZ/XXXedrVy50vbaay/TND917drV9t13X/8lfxFAAAEEEEAAAQQQSCgQKADV0nfccYe769Fll122XWYjRoywyZMnbzedCQgggAACCCCAAAIIVBUIHICq57O8vLzq8u61xgklIYAAAggggAACCCAQRCBw5NiuXTvLy8uzKVOm2FdffWWdOnWygw46yA3HFGRFzIMAAggggAACCNSXwKj/LLV/5+bZjIHd6muVrKcWAoEDUA1AP2zYMFu7dq3tsccetnHjRvc4/vjj7dVXX7XWrVvXYrXMigACCCCAAAII1J1AsXfhdCEXT9cdcMScA10Fr3Wcf/75NnjwYFu6dKm7Il6B6Mcff2yLFy+2O++8M2IxWBwBBBBAAAEEEECguQgE6gHNzc21hQsX2vTp02233XZzNllZWXbEEUfYjTfeaE899VRz8WI7EUAAAQQQQAABBCIKBOoB7dChg3Xr1s3mz5+/3epKSkps11133W46ExBAAAEEEEAAAQQQqE4gaQ/op59+alu2bHHLnXvuufY///M/NnfuXBs6dKgVFhaazgt94IEH7OWXX64ub6YhgAACCCCAAAIIILCdQNIA9LzzzrMFCxZUWujuu+82PeLTgw8+aEcddVT8JJ4jgAACCCCAAAIIIFCtQNIAVD2gQW6/yTig1doyEQEEEEAAAQQQQKAagaQBaHZ2djWLMAkBBBBAAAEEEEAAgfACgS5CCp89SyKAAAIIIIAAAgggUFmAALSyB68QqHOB8g0brPXUKVa+bl2dr4sVIIAAAgggkI4CSQ/Bp7rAupXn559/bj/96U8jZ73O+/KeN2+e9e7d2/bee+9YfhoqqqioKPa6T58+tsMOO8Re8wSBhhYoz82xVh9/aOVHH2PWs2dDF4f1I4AAAgggUO8C9dYDqmGbfv/737vbdkbdSgWZujOT7kl/3XXX2SuvvOKy3Lp1q1177bXutabpsXLlyqirY3kEEEAAAQQQQACBFArUSw/oN998YzfddJN16tTJPaqWf9OmTe6+8hrQvuoV9bfddpudfvrp1q9fv9hiGnt09OjR1r9/f/feRRdd5O5Tv2zZMttll13snnvuic3LEwQQQAABBBBAAIH0EqiXADQ/P99uvvlmW79+vbudZzzBo48+6qYpcNT95e+7777Y7T41n24Dqrst+Um9nCtWrLD999/fTerevbu1bdvW9XQuWbLEBaBvvvmmOww/ZMgQ956/rP7qXvarV6+OTSotLa10yD72RtwTDUWVkZFR43xxi1R66pe/uLg40LBWlRbe9iJqGeSmFKUM5eXlZt4j/hSHbcUL9Mcvg/6GzcMfFizs8n4ZVCduewKVvPJMnoJLYcvgt4etXhnC5uHKEKEuSkoq2kOUMqguZBh2G3yH0gjtwa/DhiyDHPQIWwa/TUZz8Jqk1yjClkH7QSW/TtyLWv6XqvYQdf8QpS7iHbTPD5OUB2Uwz6BiTxm2TfptsbQ0/PeFvrKifC5Uj0oqS7L2oPf9fZFbgP8CCdRLAOr3Xr733nuVCrVx40Z7++237cUXX7RWrVrZtGnTbMqUKXbZZZfZmDFj3LwKGJ977jl744033L3ndb5nu3btKjUG9axu8C7s0CH5xYsXu55RLTdu3DgbP368de3aNbbeZ555xuXnTzjwwAPdsv7rZH+1jigpJycnyuJu2YYsQxt9mr1H2DJkenfVaudthe6uVRbRMmwZ/AqIUhdttFPyHmHLEHPwfpiFdXBliFQXea4u9OOwtIHqInNL9DJke19yGY3cIbeg0DVL1UXYNuWCP++bNuzy/udCP/ijprBlyC2sOHe/oKAg8naELYO/7bpeIWpq7mVwbdL7ygjrkON12CgVeKfvhc2jrEw/rKJ/LmpqD5s3bzb/x4srNP8FEqiXADRRSWbNmuUOuY8dO9bNovNEFy5c6ALQww8/3E1TULnffvu5i410iD4rK2u7itYvZo1ZevHFF7uHekSV9MtLvaHnnHOOe63/Lr30Ujv77LNjr++8885KAWrsjbgnalz69dOxY8e4qcGf6teR8ujcufN2pxgEzSUdypCvHgHvER/QBy2/5iveuEE/Rq19+/bWKu5HQW3ykIOSfnSESX5daPmWLVuGycLyM71Tp72gJ6xDSc5m0+/qKA6uDF45QpfBuxBKZWgXoS4UxOtXf+i6yMuNXIb8zGhtsiTf+zHkObT1ftS2Dtkm5aAvW32+w6R129q0yhC2PjO/XW4Z3r+wy2sfqlOhtI9TZ0CYFNVh07bgV/vvsNuhAFqBQNi60LLqGIni0JTK0KFDB2vdunWY5mBZy1fq6yJ0XRZuuw14mzZtQueRufx7r+zhPxd+e6jJ4YcffnCxSSioZrxQgwag+vLSoffhw4dXqgIFe4MHD3bTXnvtNVMvpR5K2lGqB03Bpf/B0K+jnt7VxLrgSDsuPwDdbbfdbNWqVW45/z+9H79zy/S+xGsKRFQePWqaz19H1b9+17zObw2bR7qUQXuUsNtQ6v140IFf/YgIm4fqSyns8impC1eC8GUo87ZfQU8UB//gYFiHlJTBawtK4cvQwjkE+Qy6FVXznz4XSlHLEKUuorbJrKyK3XCUMjgGjyKsg+8YZR8lB32+wpYhNQ7R9tW+Q5S6kIN+kIR1SKcyRGkP/naEdWjRoqKDICsz/PdF1M+F/9muyUHv+9tbzW6KSQkE6u0q+OrWf8wxx7hD5j169LC+ffva8uXLbeLEiZUq8pBDDqk0jJIqesCAATZ16lSX5QcffGBdunRxDz3XOaVKOpw1c+ZMGzRokHvNfwgggAACCCCAAALpIdCgPaA6THLGGWfYWWedZf7h9RtuuKGSTPzhcv8NHUb3h1/SLxRdKa80YsQIdwW8hmjSBU26COmggw7yF+MvAggggAACCCCAQBoI1GsAOnDgQNMjPp177rkuANWJ5zrPIkjq1auXTZo0yZ2zFH+uj87bueuuu1zvpw6h+Ifog+TJPAgggAACCCCAAAL1I1CvAWiiTdJh9aDBZ3we8cFn/HT/HND4aTxHAAEEEEAAAQQQSA+BBj0HND0IKAUCCCCAAALpIVDgXYn/7qbNtraoYhii9CgVpUAg9QIEoKk3JUcEEEAAAQRCCSjwvOo/39r/pmBM1lAFYCEE6kmAALSeoFkNAggggAACCCCAQIUAASgtAQEEEEAAAQQQQKBeBQhA65WblSGAAAIIIIAAAggQgNIGEEAAAQQQQAABBOpVgAC0XrlZGQIIIIAAAggggAABKG0AAQQQQAABBBBAoF4FCEDrlZuVIYAAAggggAACCBCA0gYQQAABBBBAAAEE6lWAALReuVkZAggggAACCCCAAAEobQABBBBAAIEmJPBl3hb7LCc39BYVercDnbU5x9YVczvQ0IgsWKMAAWiNRMyAAAIIIIBA4xEY//0qG/Pd8tAFVuB5+ddL7V9eEEpCoK4ECEDrSpZ8EUAAAQQQQAABBKoVIACtloWJCCCAAAIIIIAAAnUlQABaV7LkiwACCCCAAAIIIFCtAAFotSxMRAABBBBAAAEEEKgrAQLQupIlXwQQQAABBBBAAIFqBQhAq2VhIgIIIIAAAggggEBdCRCA1pUs+SKAAAIIIIAAAghUK0AAWi0LExFAAAEEEEAAAQTqSoAAtK5kyRcBBBBAAAEEEECgWgEC0GpZmIgAAggggAACCCBQVwIEoHUlG5dv2dJvrP0dt1rZivC3RovLjqcIIIAAAggggECjFiAArY/qKy21jIICs7Ky+lgb60AAAQQQQAABBNJagAA0rauHwiGAAAIIIIAAAk1PgAC06dUpW4QAAggggAACCKS1AAFoWlcPhUMAAQQQQAABBJqeAAFo06tTtggBBBBAAAEEEEhrAQLQINVTUmK21Xs04lS27Dtrd/edjf5K/IwvF5keJAQQQAABBBBovAIEoAHqruUTj1mLp8YHmDONZynZapk5m71AujSNC1lz0bI+eM+y3n+v5hkTzFG2fJm1u/N2K/vu2wRzMBkBBBBAAAEE6lqgRV2vIN3zLy8vt61btyYtZrl7t+b5EmVS5g3DpFTqBX81rStRHiqnUtjly8q2laF0a+g8XBkCeCXaBt+hzBuOKux2RK4Lrzc7c8sWK/P+RitD+Loo3dYeojuEL4PWraQ6Ce3gtYUgn5+E7WFbm4zkkKLPRdQyRHEo9R0i1IXpg+E9wtalv5zapv88Ub0lmi6DSA7evkmpIdtkKj6bakuRHPz2EGU/WbGjDF2XpaXb9g8NWoZt7SFCGVyDivC58NtDTZ8Lva86J9VOoNkHoNpZbPECkqRp2461xvkSZFJWVGQtvfeKiouspKZ1JchDDTwjI6PmsiZY3i9DcXFx6DK4z5f3X2QHzyOsg/uQRylD4ba6aMgy+O0hYhkyGtjB3+lGbQ9qk1tDfi7UHlLhEKUMCthUjrAORV6bVCouLgmdR5m3fkWgYcug/aBSYWGhleiUoxApqkOh7+CtP+x2vL9ug+V6gewprVqF2AIN1Rzd4bNNmy3PaxODQpahUGNGe0n1ENahvLwiCA67fMG2MkRqk56lmmXUMpSUFIfOo6I+U/O5SPbDTF4EoLX/yDX7ADQrK8s6deqUVC7HC/wyMjKtYw3zJcqksG1b02+5tt7f1iHzUONXAFpTWROWoU1FGdp4f8OWISczwywzukObNm0sO6SD6sIsI0JdtHF1EbkMXjnCtocirx3oK75hy9CmogxeWcLWxYYNG9xON2ybLFq/3pUhOzvb2oRtD1579D4Y4eti48bIZdjo5aEvurAObcsqek6y22SHziNTn80I+wftXxR8tmvXzlq3bp1oN5J0uhz0oySsQzvvc62k9hA2j9e//MqWFRTaL/fdJ2lZE73pO2hfrXKESZO/XGLf5BfY8D57hVnc2nnfNUqqh7AOmd7nIsr3xUZ9rryUnR2+DFlZKoOF3oacrIrwpHXr8O1BDlE+F2rP/uciWXto376999VYYebg+C+QAGKBmJgJAQQQQAABBBBAIFUCBKCpkiQfBBBAAAEEEEAAgUACBKCBmBp+pswvPreMf/9vwxeEEiCAQJMT2OIdgn9n4yZb552PS0IAAQTqQ4AAtD6UU7COrI8/sqzZH6cgJ7JAAAEEKgus9i4Auvab7+zL3LzKb/AKAQQQqCMBAtA6giVbBBBAAAEEEEAAgeoFCECrd2EqAggggAACCCCAQB0JEIDWESzZIoAAAggggAACCFQvQABavQtTEUAAAQQQQAABBOpIgAC0jmDJFgEEEEAAAQQQQKB6AQLQ6l2YigACCAQSmLDqB3t8xfeB5mUmBBBAAIEKAQJQWgICCCAQQWDu5hz70Lv/N6nxC3yXn2+HffaFfbB+Q+PfGLYAgTQXIABN8wqieAgggAAC9SNQ7q2mpLzcyrwHCYGNxSU28utvbB4/MOukMRCA1gkrmSKAAAIIIIBAYxYoKiu1Dzfn2lruEFYn1UgAWiesZIoAAggggAACCCCQSIAANJEM0xFAAAEEEEAAAQTqRKBFneRKpggggAACzUpgpXc/+aKtW61rs9pqNhYBBMIKEICGlWM5BBBAAIGYwJ++W24rCwvtzV13iU3jCQIIIJBIgEPwiWSYjgACSQUyvl5iGV8tTjoPbyKAAAIIIFCdAD2g1akwDQEEahTIev89s6JCsyOOrHFeZkAAAQQQQCBegB7QeA2eI4AAAggggAACCNS5AAFonROzAgQQQAABBBBAAIF4AQLQeA2eI4AAAggggAACCNS5AAFonROzAgQQQAABBBBAAIF4AQLQeA2eI4AAAggggAACCNS5AAFonROzAgQQQAABBBBAAIF4AQLQeA2eI4AAAggggAACCNS5AAFonROzAgQQQAABBBBAAIF4AQLQeA2eI4AAAggggAACCNS5AAFonROzAgQQQAABBBBAAIF4AQLQeI0m/Ly8dKvbOv9vE97UtN+08rLybXVRGqqsZWvXWMbqVWZr1ljZ6tWh8kiHhcq3VrRJKy5Kh+I0WBm2lpW5dReUhmsPDVZwVlwnAuXlFfuHogZsD6XbypDrf0brZEuTZ1pSXvG52FBSnHxG3m20AgSgNVRdub4cCgrM8reYv2OoYZHt3i4vKXHTyrc23BdM+dw5rgxln3yyXfkCT9COoDj8zqC80LtvuJfKCxsu4ChfsbyiDNv+uhe1+K+8yCv75s1mOZutXPdBD5HK5811S5XPq31dlK1ba/m33mQZ69db5qaN7nmYILR8w8aKMqxdG2ILti1S5rXnCF+SZbM/chmV/fOf4cuw7YsyfAbRlpzrOX6Wk2tL8gts5ppwlq+s+sEV4pXvw/2Y0Hr/uSnHFm/Jt1dWfh9qgwq3BcGbSrb9KKhlLhu8/cLX+fm22vu7QvvLEOk7b3ml//U8GyoVllYEPZu27bPDlKPIs/SDpzDLv7mtHb32Q7j2lOcFjf/x2uM6bxtWFYTbR728rS36bTPMdkRdZuLylS6Ll76v+HyEya/Y+7HvB9Nhlo8t08D7mVg5mtgTAtAkFapgo2D0HZbpBSuZ3/zHCu+522K9NkmWq/pW2ZyKL9iyOR9XfSvQ67JV3pfKmh8sY9UqK/uh9h/Gsk2brOzjbV/2s9638pycQOv1Zyr3gozChx60zP/8xzK/XmKFD//FXGDuzxDwb9msD9ycZR9W/A24WGy2cn1BbfQCp00bzD2PvRPsiX5AlM54y81c+vZbtd4GrTP/9pstc+UKy/TqQoFg+ZYtwVa+ba7yvDwrfe9d96rsw1m1rosSLRv/Be/1HpbMfKdWZdDMpTPedMuU/uPtWi+rBYqee8YyFi6wDH0u/v5ErS3LvOC57IP33brLP/s0VLsunvqqZfz7/7d3HvBWVFfbX/deOghSjIpUBVSIMXb8bFGsSWwxKhakiI0YgiYhGo36RaMkxhj5TNT4gg1QEF8REIKFKhZUkCIC0kVBRSwgeBvzrWefuw9z55yp51y4R57F7zJlz95nzX+XWbN2mYVGh9IxzyS6D+fbLSkdVJ+4smTzZrngjTnyuT7ov9E6cumcd+WtKsM+alobS8vkiY9SL0WT1fBYFbM8Lfz6G+n19lz5So2OrWr4XDdvgUxLYAiP+midUXnMJ+pZjykwPnvMnC1L1ejZUFYuP5nxWuz7wE8OXbnK/PIINTysVziOKlM2fCqzNn1lDPGn1qSYxomPa59ZlzJ6Rid8Gbh54WKZ8sUmw6KXlofSKoM2qh7faj4+tGq1ufwlzcc1+lIRR2B8njbrdVm45Vv5TPPipAR58aXm56Or15ifnanleZGWsbjyxJq1Mv6zjYbD7e8vke0xDbjP9dk7TNOAvK0v/HjRiyt3L1km4z/fKCvUCO+jdeS7BC/Lyzan2vfXv/wq7s/z+ggEaIAGQCrXh/T2FcvTV1R+sFjKp01NH0fZ2a6eKufNKgN05kzZDu9ZDNmuXa1bb7vVeLuKNn2h+7cIumDjSNnY0SK2G0O9dqX/+2yc6FIxfapUvP1WOk7FW29KxYzp6eMoOzCircfPeWeOdh3He9A5WzbL1ltvlmKNV6zdzth31ACIIxWzZ4nAmIdoGhUxDeHyV14SRw1PK46+DKCMxJGy58eKVHmC4U0uHTsmTnSRoqLM64vjVeOK9xeJs2xJKp01q6VCDcA4Uq7lGfcNTfBXMWNa7PJQNgZlMtUzAC9q6TMj46ggFe/NlbLnxkiRPtjwV/7iBClXgz6uVGqeQrZXvRTEif/8x+vV05XqLrXxxlQZMPY4bDtk6TLZWmWkoH/k9sVLw6JUC5+4fkOGh+eFmMbTx/pC8/S6VL2YocbTgpht1Ki162S9q1dji/b0PLJydTU9ww5e+vQzefvLVNv4iRofj8c0IGGI931nnnyNsqR58vuF78ukKs9y2G/b8E/UUHlS7wXyhhoc78Y0Ol7UvHisymhCGi+rAfnwypRRjeMo8sDylbJRDUcIfNF3fFBVT82Z8P+eUeN9lcto/UYN0n+tiKfDvcuWyzeu3ro/vf9B+A+7roCx+Ac1xFE3UDseUYP6iZj5eY8aj7ZeIOlbVYc4Rix6BYYqSyv/1fL1UMy8QNz7lq8wSYzb8JnAuKfkl0C8J1cOv71x40aZMmWKLF0ar4H1+0m/9Eq18Zo9e7a8/vrr+nyresD5JRJyfrvq7BVHu0DjSNnoUTu6KdUILHtWH7wxpHzqq9rtXbojxnfbpFwf+FGlctVKqajyPNo4FfqwrVybesO154K2lVm6q7dnOReURumoEfqUT3VvYWuOgyJ4wspeVuPvix35gf0y9WJGFXT/G6PHFQF54bi9ia6wbLvwXnol2znvNfa4ct069VZqfrqkYuZ0qVQjMKrUPbmHSJMmOy5v1Ejq9jhtx3HIHjzXZeq9dEvp0yNjefa3q9fTK5WrMs95r7HHlRrfvAzYE7qtnPuuwDCOKpVLMh/MlUviPSjB3dHfNaIvmnF+H3Ga16ubiuv6v3ndzHOu4Gq776vRNLLK4LEBMMRmqNcmquzToEHGpXs3qJ9xLujEnR8slTI1FqzcuigexwpXXJuG1zC357Nty7VM3rG4en7+XY0geOKiymT1fla1LukoE/UlM45kcFCjJ86wq8VZhg5kO+en01rtYfEa7pPV8Jm18Qu/KBnns3n57LCCjIuznFi6eUuGsfiGGpQTYrzUzFani1dei3EPeAGy3e82nQVaV2BcRxW8kHgFacQRvFC881XqpQiG/P0fRm/j4vzO7nztTjFA582bJ3379pVly5bJ4MGD5fnnn8+JuV9629SY6NOnj0ybNk1GjBhhfitOA+JVqs4RR3pPSZ3Dj8g453eictlSgbfQLfC6Va6K8UaazbtVFD3bysb9r0jjxiKNGovTsGHVfiMpGxc9D+p0+6H7Fsx+SZZzGRdVnaiY/55ULphfLbhSz1V4zlW7wHuQzVC0nkTvtVmOy8aPE+fr6t0oGIpQ9kIMDscdL+LOD/VG1sG5iFIGb2dJiUidOuIgHd3iL85LSXGLFtLoriGyvUNH2d62ne7fI8V77RVRA3U6Tn1FtusQArc4OpmpfMpk96nA/ZLOXTLCSzplnsu4qOpE+auvSNE++4q0bCUODLYWLc1xnKEExe3aZyRf3L5DxrmgE6UjnqwWDMM8ztCSXu3aykF77HgZaKf169r9O1ZLM+jgf7Sbs12jhtJe47WpX0/aNWwg7fV42Oq1QdGqhV3ato0c3XzP9LkD9eVkwAHRdcCQgXEe42KOev7g3Y0qF7fZT5rV1bJcJXW1XvRr384ehm7/Z9UaWeny2iECxmD+beny0Lj2gjZo2zyS7ZznkvThOzq053nP8IN5anw8W+UZTl8YsHNcq5YZocdnOZdxUdWJfyxbIfW0XWiibUTD4iLdFsse2j7cu/TDyIbwBfu1lqZoV6oET4re7dvaw9DtU2s/kk76vOjSpLHsry8ynRs3EpSp0erZj+qB7LrHHhm/07Vp5rmMi6pOTFTPdfcWzU257qw6HK5xj9Xj6fpiFlWHY/R6r3TXtjOqYOjE//X0Rvxn5WpZ7SmnUdPjddkJaO9VltfX7NcmPtu7d2+58cYb5dBDD5VPtduyf//+8txzz0m9evVMml/pGMUvtQFo27atPo93VB4E3nbbbXLRRRfJD3+4wwjyS2/UqFGCtAYNGmTSveaaa4zh2717d3Oc7b9+/frJ8OHDswWZc+U6Tm3bxPGm67Pheb+Qusf+H99rvQHbht4v29XYREfEdn3LL9bGpUj/lXTpIg2uu957edbj1KSTW8wkKHOBNgYwQIqbZ1awrAlUnSxTb8IX+mbaqlUrqRvDS2PTLJvwgpSCg+pf/5xzpd7PzrZBodvvHhsmpgteGZTrm2RdzeMiZVHcurU06HNlaHxcUPnRWtl2+607vMlopO+4S0raRXvQVbw3z3T5Vujvb9au+z20kTRlTR+cdX58eCQdjB7qZftWjVZUm8bnnCd1unaLHNdeCM88PPgtW7ZM1wEbFnW7aZOOg1UdkEYcgfGH4QyVmhdbdbxhI/WglsAo1gd4vdPPjJxUqXqPyyZNNNfXUw9svct66egAdMhHF8uhhT4Y6teP57XDvZc+MVwqpk01P1in+7FS/+rrpAj3EkHK9cWwVMcye6X+FX1ieZTxoHp2xUop1wlZF3Y6QJp42i9v+tmOc+GA9DDJYpJ2c2LW9Nn77y/11XCJKhifB48TeEKPOto2FGs+7qfl4cHDfhQ1GcEEogfVkwoe1x7UReIYHPD6btbJT5XKcLN6ERur8VO3Tl0pUSPs3H33iVSuMGb0ch3nByMF0k2NluePPVqaRmzr7lLd31ODM81B8xHtNTzM/+/Hh0TSAb87TI3pIdp9XKb69OvYXm47+MDIcREfgjbqc50c2Fzb+AZZPNypq/z/xzji+/V+tmk6V3fpLEdlMcb8Y6dCctUBXeZ4sYCcslcrGXbkYdIwYt1MaYCmvlIX+vgsMYdH1WBEVz4mhV2mL4t3//BgqaN5GkUeUG/nPWr4e+WMvX8gTxyV+bxYtGiRTJ06VQYOHOiNwuMAAjVugKIgn3HGGfLKK+r1qHpAXXzxxTJkyBDp2LGjPPzwwzJp0iRp06aNqXT33XeftHMZFTfccINcccUVcthhh5nbCEpv2LBhcvrpp8uJJ55orn3kkUeMsQUj0wo8o9DFChrdoUOH2sOsW1wDSWK4IR6MT+gNgweNWmzRCRJFOonIdJIdf4JI02axk8hZB/3FXc2hSLtMi4zBoSb9yT3Ead9ht+SAm97VeWF0UKMDUleN2CSSjzJZ8eUmrWCO1IlpiJfo2M8ijat2146XQ7WfHe0pqIzxcoX7Rt2G4ZK0ffAaPUlYUgfNO82Dt9WIhPF3jHqF6yZoa/OVFyjb1sESNz/zpQPS2ZVlcoP2WmFIQAd1miSRfHAo1Wd3pbYPjbSHIY4s1klc2zQP0UBU6BKGJSXqNKmyX36svR4lnpftJTokaM6cOQJ7hRKdQHV3Y/R4ka/EG0xjdenbzEPEZs2aCTw4e+65p7z88ssyduxYU1knTpwo48aNk+uvv94YqLh2lXoQR44cKZMnT5Zjjz1WDjzwQN/0NuiYn6ZNmyKaEeyv03F3bkGFhNfHytf69u/WzZ73bnFNlOu88XBs4yVOo3kLKTvtDJNO0gYlZx2qbizxPeSDQ4eOUnb5FUYTcIjnb0vdQD44IA00jjatKjSRNzYetnY/cuSqCxFvl+ugPRi7WgfZo2kiHbZrfYLAUIAxj/JkXw6TlCuklTQvwdDGT5qGSWA31wHsDlfjADzrxfS2WX52i7RyyYtc47v1sPtJtrncg/29pGm00jrlqNMlaXz7+9gmTQOGIt5D4sbvVjW0BmUJvYdwHpmeIrdSrv246bui7ta7NW6AItPgSncL3tbRtTBr1iyTsffee68J/k7H9C1evNgYoLbbHONGu3btKh06dDBd9EHpecPwOw09Y4PgfcWfFXhH0QUYJOi6RgELu84vDdv9DcM7qQFZG3TASwMkVw54MUjqHagtOqBhSsoBBg+64HPl8H3RAcMh4nbB27qGoTswInPNi++DDmhnk3JAW4lu31w5fF90aKJeuyTd3yiXGAYGnvnIi0LXAW1dUg62Cx5lMhcOO0MHtOVBBqptr7itTqDGDVCMUftWx6Rgdrp9yMCIaK3j/5YvX2663s8777xqWsHYO+WUU8y5CRMmmO53dxe8X3oY32gNFETGPsaVUkiABEiABEiABEiABGoPgQQDEuMpD9f1McccI+PHjzcRZ+pamBhcjb+TTjrJLMu07777Srdu3eQjXZD56aefruYuP/LII6u9QQWld8IJJ5iuenhS4WHCUkzWcI2nNa8mARIgARIgARIgARKoKQI17gGF4gMGDEgvv4RxVpjZDsEYUHSHX3LJJenu9ZtuusmE2f8uu+wyu5ve+qV36qmnmjVAkR5+p2fPnmaiUzoid0iABEiABEiABEiABHY5gZ1igLZv315Gjx5txsbA6HRLr169jAGKNTwx1iOK+KUH7+idd95pltnB2E8cU0iABEiABEiABEiABGoXgZ1qoXmNT4sChmJU49PGwdYvvSRpudPlPgmQAAmQAAmQAAmQQM0RqPExoDWnOlMmARIgARIgARIgARIoRAI0QAsx16gzCZAACZAACZAACRQwARqgBZx5VJ0ESIAESIAESIAECpEADdBCzDXqTAIkQAIkQAIkQAIFTIAGaAFnHlUnARIgARIgARIggUIkQAO0EHONOpMACZAACZAACZBAAROgAVrAmUfVSYAESIAESIAESKAQCdAALcRco84kQAIkQAIkQAIkUMAEaIAWcOZRdRIgARIgARIgARIoRAI0QAsx16gzCZAACZAACZAACRQwARqgBZx5VJ0ESIAESIAESIAECpHATv0WfG0EVFlZKX379g1U7dtvv5WioiJp1KhR4HV+gRUVFbJ161Zp3LixlJSU+F0WeD5fOuAe6tRJlu21QQdwhOSaF7lwgA6O45j8DMw0n0BbHnalDij3yE/qQA4opt+n8rB9+3Zp0qSJT+0LPp0vDoWuA/TfsmVLzu1DLhysDg0bNpS6desGZ5xP6LZt20zZTloe0M5v3rxZwnRAm37WWWf5aMHTvgQUMCWEQO/evZ0BAwaEXOUf/M477zhdunRx3n//ff+LQkLUSHauueaakKv8g+fNm2d0WLhwof9FISFXXnmlc9VVV4Vc5R88f/58owO2SaV///4O/pLKggULjA7vvfde0iScq6++2unXr1/i+IsWLTI6zJ07N3Ea1157rdOnT5/E8RcvXmx0QNlMKqgTqBtJ5YMPPjA6zJkzJ2kSzq9+9Svn8ssvTxx/2bJlRoc333wzcRoDBw50Lr300sTxly9fbnR4/fXXE6cxaNAg55JLLkkcf8WKFUaH2bNnJ07jhhtucC6++OLE8VetWmV0mDVrVuI0fvvb3zoXXnhh4vhr1qwxOsyYMSNxGr///e+dCy64IHH8tWvXGh2mT5+eOI3Bgwc7559/fuL469atMzq8+uqridO4+eabnXPPPTdx/PXr1xsdXn755cRp3HLLLc7ZZ5+dOP6GDRuMDi+99FLiNBjRnwC74H1NcwaQAAmQAAmQAAmQAAnUBAEaoDVBlWmSAAmQAAmQAAmQAAn4Eii5Q8U3lAGGAMafdO3aVQ444IBERDDus3nz5nLUUUclHruIcZvdunWTTp06JdIBY1itDhiLmkSgAzjkqsPRRx+dePwk8uLggw+Wzp07J7kFKS4ulj333NPkRVIO+dQh6dgk6HDQQQeJDu1IzKFZs2aCvNjVOqBe7LHHHonuI1cOqBfgkIsOqBfIiwMPPDDRPUCHpk2bGh2wTSLQAb9fG3QAiyQCDigHKJO5cECdyIcOKBdJxOZFUh3QRqFOgkNSHVAv0EairUwibh3QXiYRcEBeJNUBv2k55KIDOOC5lURQJvGcQPuA5yclvwSK0Duf3ySZGgmQAAmQAAmQAAmQAAn4E2AXvD8bhpAACZAACZAACZAACdQAARqgNQC1JpLEkhQUEXJIlQJyIAd3e8DywPLA8uAmwPKQSaP2naEBGpIn5eXlZr3EkMt8g7E+2MaNG33DowToUjmiy/6YtSejXF8T15DDDqpfffXVjoOYe/koD19//bXoUlCiyxjF/PX8Xk4OKZ7kQA7umsXywPLgLg/c9ydAA9Sfjej6Y6LrmImubSf33HOPwHiIK7p+mOh6ifLpp5/GjWquh/H55z//WT7//PNEacBwfOyxx0TXCBRdP1N0fbvYepBDCpmujSe9evUSXfNRdP1JWblyZWyWuZYHGJ+/+c1vBFtd2zX27+ejPJADy4O74LE8sDywPLgJcD8qARqgPqS+/PJLGTlypDzxxBMyevRo+fDDD+XFF1/0udr/9H777Sf4GsOvf/3r2AakNT7/8pe/yOGHHy66WLT/D/mEDB8+XD7++GMZNmyYXHfddXL//ffLP//5z8jeVHLYAfaBBx4QXQBeJk6cKD/60Y8Ex3Ell/Jgjc/jjz/e5GUSAzjX8oD7JYdUrpMDOaQIkAM5uAlwPyoBGqA+pGBsdu/eXfbaay+zDMPPf/5z0a/H+Fztf3r//feXDh06yDnnnJM2QmHUhS0+sHTpUuP5hPF5yCGHmCU1kni89AsvcuaZZ5rln4444gjRr8bIpEmTZNSoUf5Ku0LIIQUDRrx+oUSOO+44s5TTRRddlKgLPGl5gPddvzQjMD7hycbyJvo1p9hjYnMtD+TA8uBqHszLLeuFkENVoWD74K4d3A8jQAPUhxA8VfBAWkm6DhnWtfvmm2+M4WeNUHjRYGAGCdYchbcSxicExvDkyZOltLQ0KFpGWJs2bWTatGnp8/j+N8YPwounnwZNn/fbIYcUGeQ/xnZ98skn5sTOLg9YU+8Pf/iDMT6hAPIFa/299dZbKQUj/p9reSCHFGhyIAd3lWN5YHlwlwfuRyNAA9SH009+8hOB99HK1q1bpX79+uYQhgjCysrKbHDgFl7Uzz77TE455RQzoQlGZNiitjA43Avfw+PVvn37asZk4I9WBcLYnTlzpug3ks04Vng0zzjjDDOOUb/7HJrE7s4BLw+VlZXGC47hGK1btzbM3OUBJx5++GFZsmRJBs9sk7filgerg3uRcSyQrN+blnHjxmX8pveEW4dcywMWZU7CwasTjuNysGkk5WDjY0sOKRrkkBsHWzeT1gt33UxpEr9eWB2S1gu3DiwPuZUHm4fcRiNAA7SKE7o4MaYLXkp4CGfNmiV77713miIMDngzYXxiEsi+++4r9erVS4djZ/r06WbC0oUXXmjGXKJiQzp27GjSQxcqDMFf/vKXxpvl7Yb36gDD0S2YDPXkk0+aMaXu8+59rw4/+MEPzCQkjFnEH4wH3EeLFi2MZ9Yd1+4PHTpUpkyZYg5h6MTlMH/+fLntttsyJm1F5YAfdutg9bLbKBy8OsBjiMlYUTnA6MRLRs+ePQXd7TDc99lnH6uC2PKAEyg3GB7Rtm3bdDh2/CZvReWQTQf3D/z0pz+VhQsXyoIFC9ynq+17dUBexuGAMvzQQw8ZYxflHpPp4nJAObaTt1577bW0flE5ZNMhnYjuROHg1SFuechWN+Ny8NbNfLcPUTh4dci1fUA+xOXgrZs2L6OWB1wf1D5E4eDVIW55yFY343Lw1k2UMUhUDtl0MAlU/ReFg1cHtg+XCtqouOXBzZ37MQjgS0gUx3nhhRecO+64w9mwYYOj4+ScX/ziF84jjzySRjNixAjnvvvuc6644gpHJ/Skz9sdnaXu6ExzR5fGcT766CNn8ODBjr5NOps2bXLUmHNOOukk59VXX7WXO7jeK2E64HrthnX+9re/eaOa4yAdcIGuFeiMGTPG0S55p3fv3s7q1auzpqOTlJwTTzzR+e9//5sRHsYBEbRxd3SsovOnP/3J0YdsOo2oHBAhSAeEB3FAuJ8OCIvCQQ1OZ8iQIY56q02ennzyyc4XX3yB6EZ0rJOjs+GNnvrC4mzZssUGmS3yHYzV823C+vbt66i30oRF5RCmAxJDHukLTcbvIyxIB4RH4fDcc8859957r0lLDfKMshfGQQ1Wp0+fPo7OlHamTp3qnHXWWfhpI1E5hOmAxII4BOmAuFE4hNXNMA5BdTMqhzAdwjgE6RCVA64LqpthHBDfr25G5RCmA8KDygPC/XRAWJTyEFY3wzgE1c2oHMJ0wL0EcQjSISqHsLoZxiGobkblEKZDGIcgHaJywHWU+AT4LfgqYx0z3tE1je/WYpxcjx495D//+Y8Zc4lxmGp8GE/QeeedZ9bk9Nr4GIuHrnU1XM13jBEf4zy1cpgZyxjDecwxx6SjNWrUKL1vd8J0wHVHHnmk0QXfhfdKkA64N3hcli1bJosWLTI64U07m2CSEvR//PHHpWXLltW+/R7GAelhspY24rJ582bBpJcTTjjBTNzBBBx83ziMA9II0gHhQRwQ7qcDwpBPYRzU+JQrr7zSeH9btWplxgO2CEDuAAAMyUlEQVSjXOAPguEY+oJiuuf/8Y9/ZHzbHvkO75K+eBhPObwV6KIHi6gcwnSAHp06dTL5iu9Oez3yQTogbhQO8DSp8Ww8AvCGo2cAqzFgLHEHnVzXoEGDQA7IR/BTA954iLGiBMohPMYok5hUFVYewnSAXkEcgnTAd6K12QwtD2F1M6w8BNVNrE6Rr/YhiEOQDvlqH8I4oNz51c2o9QJphLUPQRyCdEBYlHoRVjfDOATVzagcwnTAvQRxCNIhKoewurm7tA/gRYlPgF3wVcxgeKI7wgoemn//+99l7NixppsTD8lBgwZlNT4RB/FhbMHoghQXF8uNN95oxnrCkM1mMJoLXf+F6YBLMdgdXcLZJEgHGEtoDDA8AJNZ3ONLvWnpG6GcffbZZhLUgw8+mO6Ox3VhHHCNepHNslF//etfzXqVWMcU3UswFKJwQBpBOiA8iAPC/XRAWBQO6IJxT0Jr1qxZtZULYOxhLdBsxid+wxsf+lqJysGbhlcHm95ll12WYQAjzBvfrQPCo3A49NBDBes8QsaPH28McAw/+de//iXqDTdGbxAHDHlQL4iJjzVQ0U2J+8CwAQxJgeEcJmE62Ph+HIJ0QJ3GZK6wehFWN8PKQ1DdzGf7ABZ+HIJ0yFf7EMYB+vnVzaj1AmmEtQ+4xo8Dwvx0QFiUeuGtW966GcbBG99dN6Ny8Kbh1QH3AvHj4I3v1gHxonAIq5thHILqZiG1D+BFSUAgvtP0+xlD1+p0dJyaowZntRvU2eKOGqLVzvkd6Fg5R8fJVet2RjcHuvOjSG3QAXrqepNpdXX9U0eXoDJdOemTITvodlcPmbnqu+++cwYOHJjRHR+SxC7XQb9eZbrfrZ7aGDrqtTOHc+bMcZ566ikblHWLbjx9yKXDJkyYYIZw4IQuw+Xcdddd1dJPX+jaqQ06uIdQrF+/Pq2dekIdXdIrfRy0Y9NAubLlAmUd3fErV64MimrCbHwc7EwddJJhemhD0rqJvLaSpH2obTrgXpK0D24OSdoHN4ekOkBvfRE22ZGrDknrptUhafvg5lAbdEhaNy0HZIZNA+eitg9uDjY+0orTPuSqA36PkhuB3dYD6h2MX1JSImoUmAka6Ca0Au+IFlR7mN7Cq4PF5eEpvP32242X6KqrrjJevptuuslMUsHFeItEd6UaYum4dqc26qCV2QwhsDqiCwfLQcET6vYQ2/BsHDCD3w4xQFeUjllNe0LRNe8VL4faoEPTpk2rdWmrASJNmjSRt99+W+6880457LDDqt2GlwOO407e8nKoDTpo85K+T/ckC+QrJrN5xcsB3lOUBwjux5YL1Df8ZUvDy2FX6OCdnIF7iNM+ZPs6UNz2oTbqgJ4M5KOVsPYhG4e47YOXQ1wdsk3WyVUHeBvh3bMS1j54dcAQgrjtg5dDbdDB3j+2UdoHLwcdxxq7ffBy2BU6uH+T+zkQyM1+LczYQYPxtcE0nh3tPnd0aR0zsUjXy8y4Ue26c+AdhYdTZ6YbL6F22Tp4M9PPdjraTe48+uijxiMKz4dXarsOXn3hCdWxo97Tjh8H74XwhOo6pt7TZjKW3+Qt78W7UgcdD+o888wzjr5wJOIQNnkrqDxYDrtahzVr1pjeAHhzMRlPxxRa1dLboPIAT4W+zDiIjwlqmNzklTAOO0OHoMkZUduH3/3ud47OpnX0gWvaEfQCQKK2D7VdB2+++dVNPw7e+H7tQxAHbxp+OkSZrIO0ctEhrG6G6RDWPkThsKt1iFI3gzhEaR/COOwMHbzljsfJCWBc224nmI2LLlAreEjgYaiTAUx3gA5CNzN2MdtdJ47Yy9JbVBR0HyKeFV1Ts1qXog60N7PlddybmVVpr7PbQtDB6uq3jcLBL649H8bBXue33Vk6wGA6/fTTsxqfUXTAfWJlgGwrKODeonDY1Tqgy+/pp592dOKBowvyZ2RJGAcYX7hPHRvsqCc5I34UDjtDBwyvcL806mQN5+67707rG9Y+wEjFC6gVPDRPO+00e2i2Ye1DIehQ7YayHEThkCVatVNhHKpd7HPQr1+/au349ddfb1Y68bk843QUHYLqJhIM0yGsfSgEHcLqZhiHKO1DGIedoUNGAeGJxAR2SwMU40QwrlEX8E2DgzH5xz/+0dGu5vS5oB3tTnNmzJhR7RIYm1iaB2/SYUIdUoQKhcPcuXOzGp82n8PKA8Y2eccX27jYRuFQG3Rw65xtP4xDtjjuc1E4uK/Ptp+rDjAG4E2yguXT3AaoPe+3xZJceFnR4QjmEoz38xqgfnHteeqQIpErB6QC4xAeRiu33HKL88Ybb9jD0G0UHcLqZpgOYe1DoegQBjOMQ1j8KBzC0shVh7D0GR6dwG5hgOJBoAujO3gwPfvss4ZO3AkBMDbRvYhJRuiKxh+6Y71raepC8w4aI69QhxQRciAHd92ojeUhyQQRb/sAQ9oKDFK88FpB24P1gt3i5UAdUm11PjjAKwavtZWwCYU1kRfUIfXcLEQOttxwm38C3/tJSFjvEevsYW01LF+EdS0haoxGnjCErwfhU4uYcHTUUUeZZWSwnBDWR8TXYdzfdcekJXwtyS3UIUWDHMihEOoFlsGJM0EkW/vgnpAR9tWsbPWCOqTa6nxwQJsfdcJQTeUFdUg9NwuNg7u94n4NEMi/TVu7UsQXaLyTX+C9hMdC1+wMnTCEQc36SbNqX8FBdwm+loRleV555RUTjskVmHyEr75gLJxbqEOKBjmQQyHVCzuUJmiCSFj7gPuFRy3oq1lB9YI6pNrqfHFAfgRN1tkZeUEdUsvZFQIH6EipOQKp9VFqwLCtDUliuQ5dZ1D0s5JGHSx+/e9//1v0U5nm6yzwaj6uX/vBl110TJD87Gc/k1NPPbWa6jqzUrp27Wq+na6GpejMd7NUE5bkgWdDx3qZ77OrIWq+/oNFubHEhxXqkCJBDuRQqPWidevWpgdEjZOMD1FEaR/69+9vFj7HF4C8Hy6IWi+oQ6qtzpXDgAEDBGkMHz7c5IX7wxg7Ky+oQ+q5Wds52Gc4tzVHoAi2bc0lv+tT1nGbRgkYj8uXLxf1REjPnj3NpxQRdv7555vPJfppqsvCiC45I8cdd5y8++675osz6NLHsS6ubLr19Xu7Zk1DvzSoQ4oMOZCDu44USnnAsBvtRZELLrjArb7Zj9o+6HfczadHGzdunJFGFA7UIdVW54MDHBHokncbnzZTdlZeUIeLBM/N2s7Blgtua4hAzTlXa0fK6GYfNWqUM2bMmGpf8IB2WHYJX7UJEzVczfI5mA3rXnoJaxaeeeaZYdFNVz91cMihqqSwTKZAkAM5uBtPlgeWh9pWHtz6cD//BHaLWfAWm9t4xLguzIrXbhcbHGlr08ASTpgR717eI0oCNj6upQ4pYuRADqwXqTJADuSQIkAOtY2DWx/u54fAjsGKNeRhrS3J6jIcZtb6AQccILpEimC2Oj6piM8BRhWddGQ+x3fIIYfI/PnzpUePHqY7P2p86pAiRQ7k4K4zLA8sDywPbgIsD24ataF9cOvD/fwR+N6PAXWj+vTTT0W/WGQmIGEMZxzj06ajn9sU/QqMdO7cWQ4++GB7OvKWOqRQkQM5uCsNywPLA8uDmwDLg5tGbWgf3PpwPz8EdisDND/ImAoJkAAJkAAJkAAJkEAuBL73C9HnAodxSYAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAI0QAPgMIgESIAESIAESIAESCD/BGiA5p8pUyQBEiABEiABEiABEgggQAM0AA6DSIAESIAESIAESIAE8k+ABmj+mTJFEiABEiABEiABEiCBAAL/H99KWfRDddtnAAAAAElFTkSuQmCC" /><!-- --></p>
+<p>Don’t freak out! Those are wide error bars, but nothing went wrong – it’s just really hard to estimate the true number of unknown species in soil. <code>breakaway</code> was developed to deal with this, and to make sure that we account for that uncertainty when we do inference.</p>
+<p>We can get a table of the estimates and their uncertainties as follows:</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb5-1" data-line-number="1"><span class="kw">summary</span>(richness_soil) <span class="op">%&gt;%</span><span class="st"> </span>as_tibble</a></code></pre></div>
+<pre><code>## # A tibble: 32 × 7
+##    estimate  error lower   upper sample_names name      model            
+##       &lt;dbl&gt;  &lt;dbl&gt; &lt;dbl&gt;   &lt;dbl&gt; &lt;chr&gt;        &lt;chr&gt;     &lt;chr&gt;            
+##  1    5257.  203.  4010.  54003. S009         breakaway Kemp             
+##  2    5343. 2252.  4317. 316529. S204         breakaway Kemp             
+##  3    4609.  978.  2782. 250548. S012         breakaway Kemp             
+##  4    5446. 1393.  3864. 299572. S207         breakaway Kemp             
+##  5    5359.  143.  4370.  35608. S202         breakaway Kemp             
+##  6    3882.  181.  2802.  44399. S007         breakaway Kemp             
+##  7    4906. 4787.  3111. 748118. S022         breakaway Kemp             
+##  8    5215.  343.  3327. 106472. S024         breakaway Negative Binomial
+##  9    4509.   98.9 3443.  24952. S032         breakaway Kemp             
+## 10    5070.  114.  4189.  27300. S212         breakaway Kemp             
+## # … with 22 more rows
+</code></pre>
+<p>If you haven’t seen a <code>tibble</code> before, it’s like a <code>data.frame</code>, but way better. Already we can see that we only have 10 rows printed as opposed to the usual bagillion.</p>
+<h2 id="inference">Inference</h2>
+<p>The first step to doing inference is to decide on your design matrix. We need to grab our covariates into a data frame (or tibble), so let’s start by doing that:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb7-1" data-line-number="1">meta &lt;-<span class="st"> </span>subset_soil <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-2" data-line-number="2"><span class="st">  </span>sample_data <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-3" data-line-number="3"><span class="st">  </span>as_tibble <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb7-4" data-line-number="4"><span class="st">  </span><span class="kw">mutate</span>(<span class="st">&quot;sample_names&quot;</span> =<span class="st"> </span>subset_soil <span class="op">%&gt;%</span><span class="st"> </span>sample_names )</a></code></pre></div>
+<p>That warning is not a problem – it’s just telling us that it’s not a phyloseq object anymore.</p>
+<p>Suppose we want to fit the model with Day as a fixed effect. Here’s how we do that,</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">combined_richness &lt;-<span class="st"> </span>meta <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb8-2" data-line-number="2"><span class="st">  </span><span class="kw">left_join</span>(<span class="kw">summary</span>(richness_soil),</a>
+<a class="sourceLine" id="cb8-3" data-line-number="3">            <span class="dt">by =</span> <span class="st">&quot;sample_names&quot;</span>)</a>
+<a class="sourceLine" id="cb8-4" data-line-number="4"><span class="co"># Old way (still works)</span></a>
+<a class="sourceLine" id="cb8-5" data-line-number="5">bt_day_fixed &lt;-<span class="st"> </span><span class="kw">betta</span>(<span class="dt">chats =</span> combined_richness<span class="op">$</span>estimate,</a>
+<a class="sourceLine" id="cb8-6" data-line-number="6">                      <span class="dt">ses =</span> combined_richness<span class="op">$</span>error,</a>
+<a class="sourceLine" id="cb8-7" data-line-number="7">                      <span class="dt">X =</span> <span class="kw">model.matrix</span>(<span class="op">~</span>Day, <span class="dt">data =</span> combined_richness))</a>
+<a class="sourceLine" id="cb8-8" data-line-number="8"><span class="co"># Fancy new way -- thanks to Sarah Teichman for implementing!</span></a>
+<a class="sourceLine" id="cb8-9" data-line-number="9">bt_day_fixed &lt;-<span class="st"> </span><span class="kw">betta</span>(<span class="dt">formula =</span> estimate <span class="op">~</span><span class="st"> </span>Day, </a>
+<a class="sourceLine" id="cb8-10" data-line-number="10">                      <span class="dt">ses =</span> error, <span class="dt">data =</span> combined_richness)</a>
+<a class="sourceLine" id="cb8-11" data-line-number="11">bt_day_fixed<span class="op">$</span>table</a></code></pre></div>
+<pre><code>##             Estimates Standard Errors p-values
+## (Intercept) 4547.1078        125.8542    0.000
+## Day2         139.5325        170.1855    0.412
+</code></pre>
+<p>So we see an estimated increase in richness after 82 days of 122 taxa, with the standard error in the estimate of 171. A hypothesis test for a change in richness (i.e., a test of a null of no change) would <em>not be rejected</em> at any reasonable cut-off (p = 0.412).</p>
+<p>Alternatively, we could fit the model with plot ID as a random effect. Here’s how we do that:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1"><span class="co"># Old way (still works)</span></a>
+<a class="sourceLine" id="cb10-2" data-line-number="2">bt_day_fixed_id_random &lt;-<span class="st"> </span><span class="kw">betta_random</span>(<span class="dt">chats =</span> combined_richness<span class="op">$</span>estimate,</a>
+<a class="sourceLine" id="cb10-3" data-line-number="3">                                       <span class="dt">ses =</span> combined_richness<span class="op">$</span>error,</a>
+<a class="sourceLine" id="cb10-4" data-line-number="4">                                       <span class="dt">X =</span> <span class="kw">model.matrix</span>(<span class="op">~</span>Day, <span class="dt">data =</span> combined_richness),</a>
+<a class="sourceLine" id="cb10-5" data-line-number="5">                                       <span class="dt">groups=</span>combined_richness<span class="op">$</span>ID)</a>
+<a class="sourceLine" id="cb10-6" data-line-number="6"><span class="co"># Fancy new way </span></a>
+<a class="sourceLine" id="cb10-7" data-line-number="7">bt_day_fixed_id_random &lt;-</a>
+<a class="sourceLine" id="cb10-8" data-line-number="8"><span class="st">  </span><span class="kw">betta_random</span>(<span class="dt">formula =</span> estimate <span class="op">~</span><span class="st"> </span>Day <span class="op">|</span><span class="st"> </span>ID, </a>
+<a class="sourceLine" id="cb10-9" data-line-number="9">               <span class="dt">ses =</span> error,  <span class="dt">data =</span> combined_richness)</a>
+<a class="sourceLine" id="cb10-10" data-line-number="10">bt_day_fixed_id_random<span class="op">$</span>table</a></code></pre></div>
+<pre><code>##             Estimates Standard Errors p-values
+## (Intercept) 4475.4249        119.2010     0.00
+## Day2         257.7939        161.2601     0.11
+</code></pre>
+<p>Under this different model, we see an estimated increase in richness after 82 days of 258 taxa, with the standard error in the estimate of 161. A hypothesis test for a change in richness still would <em>not be rejected</em> at any reasonable cut-off (p = 0.11).</p>
+<p>If you choose to use the old way, the structure of <code>betta_random</code> is to input your design matrix as <code>X</code>, and your random effects as <code>groups</code>, where the latter is a categorical variable. Otherwise, the input looks like how you would hand this off to a regular mixed effects model in the package <code>lme4</code>!</p>
+<h1 id="using-betta-with-divnet">Using <code>betta</code> with DivNet</h1>
+<p>Maybe you don’t care about richness… but you care about Shannon or Simpson diversity! <a href="https://github.com/adw96/DivNet"><code>DivNet</code></a> is our <code>R</code> package for estimating Shannon and Simpson diversity.</p>
+<p>DivNet can be slow when you have a large number of taxa (but we are working on it!), so to illustrate we are going to estimate phylum-level Shannon diversity:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">soil_phylum &lt;-<span class="st"> </span>subset_soil <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb12-2" data-line-number="2"><span class="st">  </span><span class="kw">tax_glom</span>(<span class="dt">taxrank=</span><span class="st">&quot;Phylum&quot;</span>)</a></code></pre></div>
+<p>Easter egg: <code>phyloseq::tax_glom</code> can be incredibly slow! <a href="https://github.com/mikemc">Mike McLaren</a> is a total champ and rewrote it faster – check out his package <a href="https://github.com/mikemc/speedyseq"><code>speedyseq</code></a> and <code>speedyseq::tax_glom</code> in particular.</p>
+<p>Let’s treat all samples as independent observations (<code>X = NULL</code>) and fit the DivNet model:</p>
+<p>(Check out the full documentation for details, including how to run in parallel)</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb13-1" data-line-number="1">dv &lt;-<span class="st"> </span>DivNet<span class="op">::</span><span class="kw">divnet</span>(soil_phylum, <span class="dt">X =</span> <span class="ot">NULL</span>)</a></code></pre></div>
+<p>This produces an object containing common diversity estimates:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1">dv</a></code></pre></div>
+<pre><code>## An object of class `diversityEstimates` with the following elements:
+##   -  shannon 
+##   -  simpson 
+##   -  bray-curtis 
+##   -  euclidean 
+##   -  shannon-variance 
+##   -  simpson-variance 
+##   -  bray-curtis-variance 
+##   -  euclidean-variance 
+##   -  X 
+##   -  fitted_z 
+## Access individual components with, e.g., object$shannon and object$`shannon-variance`
+## Use function testDiversity() to test hypotheses about diversity
+</code></pre>
+<p>We can look at the first few Shannon diversity estimates with the following:</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb16-1" data-line-number="1">combined_shannon &lt;-<span class="st"> </span>meta <span class="op">%&gt;%</span></a>
+<a class="sourceLine" id="cb16-2" data-line-number="2"><span class="st">  </span><span class="kw">left_join</span>(dv<span class="op">$</span>shannon <span class="op">%&gt;%</span><span class="st"> </span>summary,</a>
+<a class="sourceLine" id="cb16-3" data-line-number="3">            <span class="dt">by =</span> <span class="st">&quot;sample_names&quot;</span>)</a>
+<a class="sourceLine" id="cb16-4" data-line-number="4">combined_shannon</a></code></pre></div>
+<pre><code>## # A tibble: 32 × 12
+##    Plants DayAmdmt Amdmt ID    Day   sample_names estimate   error lower upper name  model
+##    &lt;chr&gt;  &lt;chr&gt;    &lt;chr&gt; &lt;chr&gt; &lt;chr&gt; &lt;chr&gt;           &lt;dbl&gt;   &lt;dbl&gt; &lt;dbl&gt; &lt;dbl&gt; &lt;chr&gt; &lt;chr&gt;
+##  1 1      01       1     D     0     S009             2.04 0.00368  2.04  2.05 DivN… Aitc…
+##  2 1      21       1     D     2     S204             1.98 0.00167  1.98  1.98 DivN… Aitc…
+##  3 0      01       1     B     0     S012             2.00 0.00358  2.00  2.01 DivN… Aitc…
+##  4 0      21       1     B     2     S207             2.04 0.00318  2.04  2.05 DivN… Aitc…
+##  5 0      21       1     B     2     S202             2.01 0.00183  2.01  2.02 DivN… Aitc…
+##  6 0      01       1     B     0     S007             2.04 0.00753  2.03  2.06 DivN… Aitc…
+##  7 0      01       1     B     0     S022             2.04 0.00275  2.03  2.04 DivN… Aitc…
+##  8 1      01       1     D     0     S024             2.01 0.00380  2.00  2.01 DivN… Aitc…
+##  9 0      01       1     B     0     S032             1.99 0.00317  1.99  2.00 DivN… Aitc…
+## 10 0      21       1     B     2     S212             2.02 0.00226  2.02  2.03 DivN… Aitc…
+## # … with 22 more rows
+</code></pre>
+<p>You might notice that the estimates are not different from the plug-in estimate (only because we used <code>X = NULL</code>), but we have standard errors! That’s the real advantage of using DivNet :)</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb18-1" data-line-number="1">bt_day_fixed_id_random &lt;-<span class="st"> </span><span class="kw">betta_random</span>(<span class="dt">formula =</span> estimate <span class="op">~</span><span class="st"> </span>Day <span class="op">|</span><span class="st"> </span>ID, </a>
+<a class="sourceLine" id="cb18-2" data-line-number="2">               <span class="dt">ses =</span> error,  <span class="dt">data =</span> combined_shannon)</a>
+<a class="sourceLine" id="cb18-3" data-line-number="3">bt_day_fixed_id_random<span class="op">$</span>table</a></code></pre></div>
+<pre><code>##                Estimates Standard Errors p-values
+## (Intercept)  2.015975287     0.004670871    0.000
+## Day2        -0.007668941     0.006591737    0.245
+</code></pre>
+<p>and similarly for no random effects.</p>
+<p>If you are interested in generating confidence intervals for and testing hypotheses about linear combinations of fixed effects estimated in a <code>betta</code> or <code>betta_random</code> model, we recommend using the <code>betta_lincom</code> function.</p>
+<p>For example, to generate a confidence interval for (\beta_0 + \beta_1) (i.e., intercept plus ‘Day2’ coefficient, or in other words, the mean Shannon diversity in soils on day 82 of the experiment) in the Shannon diversity model we fit in the previous code chunk, we run the following code:</p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb20-1" data-line-number="1"><span class="kw">betta_lincom</span>(<span class="dt">fitted_betta =</span> bt_day_fixed_id_random,</a>
+<a class="sourceLine" id="cb20-2" data-line-number="2">             <span class="dt">linear_com =</span> <span class="kw">c</span>(<span class="dv">1</span>,<span class="dv">1</span>),</a>
+<a class="sourceLine" id="cb20-3" data-line-number="3">             <span class="dt">signif_cutoff =</span> <span class="fl">0.05</span>)</a></code></pre></div>
+<pre><code>##   Estimates Standard Errors Lower CIs Upper CIs p-values
+## 1  2.008306     0.006591737  1.995387  2.021226  &lt; 1e-20
+</code></pre>
+<p>Here, we’ve set the <code>linear_com</code> argument equal to <code>c(1,1)</code> to tell <code>betta_lincom</code> to construct a confidence interval for (1 \times \beta_0 + 1 \times \beta_1). Because we set <code>signif_cutoff</code> equal to (0.05), <code>betta_lincom</code> returns a (95% = (1 - 0.05)*100%) confidence interval. The p-value reported here is for a test of the null hypothesis that (1 \times \beta_0 + 1 \times \beta_1 = 0) – unsurprisingly, this is small. (If you are confused about why this is “unsurprising,” remember that (\beta_0 + \beta_1) represents a mean Shannon diversity in soils on day 82 of the experiment of Whitman et al. When can a Shannon diversity be zero?)</p>
+<p>The syntax and output using <code>betta_lincom</code> with a <code>betta</code> object as input is exactly the same as with a <code>betta_random</code> object, so we haven’t included a separate example for this case.</p>
+<p>And there you have it! That’s how to do hypothesis testing for diversity!</p>
+<p>If you use our tools, please don’t forget to cite them!</p>
+<ul>
+<li><code>breakaway</code>: Willis &amp; Bunge. (2015). <em>Estimating diversity via frequency ratios</em>. Biometrics. <a href="https://doi.org/10.1111/biom.12332">doi:10.1111/biom.12332</a>.</li>
+<li><code>DivNet</code>: Willis &amp; Martin. (2018+). <em>DivNet: Estimating diversity in networked communities</em>. bioRxiv. <a href="https://doi.org/10.1101/305045">10.1101/305045</a>.</li>
+<li><code>betta</code>: Willis, Bunge &amp; Whitman. (2016). <em>Improved detection of changes in species richness in high diversity microbial communities</em>. Journal of the Royal Statistical Society: Series C. <a href="https://doi.org/10.1111/rssc.12206">doi:10.1111/rssc.12206</a>.</li>
+</ul>
+
+</body>
+</html>

--- a/vignettes/diversity-hypothesis-testing.html.asis
+++ b/vignettes/diversity-hypothesis-testing.html.asis
@@ -1,0 +1,5 @@
+%\VignetteIndexEntry{diversity-hypothesis-testing}
+%\VignetteEngine{R.rsp::asis}
+%\VignetteKeyword{diversity}
+%\VignetteKeyword{hypothesis}
+%\VignetteKeyword{testing}

--- a/vignettes/intro-diversity-estimation.html
+++ b/vignettes/intro-diversity-estimation.html
@@ -1,0 +1,726 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<style type="text/css">
+@font-face {
+font-family: octicons-link;
+src: url(data:font/woff;charset=utf-8;base64,d09GRgABAAAAAAZwABAAAAAACFQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABEU0lHAAAGaAAAAAgAAAAIAAAAAUdTVUIAAAZcAAAACgAAAAoAAQAAT1MvMgAAAyQAAABJAAAAYFYEU3RjbWFwAAADcAAAAEUAAACAAJThvmN2dCAAAATkAAAABAAAAAQAAAAAZnBnbQAAA7gAAACyAAABCUM+8IhnYXNwAAAGTAAAABAAAAAQABoAI2dseWYAAAFsAAABPAAAAZwcEq9taGVhZAAAAsgAAAA0AAAANgh4a91oaGVhAAADCAAAABoAAAAkCA8DRGhtdHgAAAL8AAAADAAAAAwGAACfbG9jYQAAAsAAAAAIAAAACABiATBtYXhwAAACqAAAABgAAAAgAA8ASm5hbWUAAAToAAABQgAAAlXu73sOcG9zdAAABiwAAAAeAAAAME3QpOBwcmVwAAAEbAAAAHYAAAB/aFGpk3jaTY6xa8JAGMW/O62BDi0tJLYQincXEypYIiGJjSgHniQ6umTsUEyLm5BV6NDBP8Tpts6F0v+k/0an2i+itHDw3v2+9+DBKTzsJNnWJNTgHEy4BgG3EMI9DCEDOGEXzDADU5hBKMIgNPZqoD3SilVaXZCER3/I7AtxEJLtzzuZfI+VVkprxTlXShWKb3TBecG11rwoNlmmn1P2WYcJczl32etSpKnziC7lQyWe1smVPy/Lt7Kc+0vWY/gAgIIEqAN9we0pwKXreiMasxvabDQMM4riO+qxM2ogwDGOZTXxwxDiycQIcoYFBLj5K3EIaSctAq2kTYiw+ymhce7vwM9jSqO8JyVd5RH9gyTt2+J/yUmYlIR0s04n6+7Vm1ozezUeLEaUjhaDSuXHwVRgvLJn1tQ7xiuVv/ocTRF42mNgZGBgYGbwZOBiAAFGJBIMAAizAFoAAABiAGIAznjaY2BkYGAA4in8zwXi+W2+MjCzMIDApSwvXzC97Z4Ig8N/BxYGZgcgl52BCSQKAA3jCV8CAABfAAAAAAQAAEB42mNgZGBg4f3vACQZQABIMjKgAmYAKEgBXgAAeNpjYGY6wTiBgZWBg2kmUxoDA4MPhGZMYzBi1AHygVLYQUCaawqDA4PChxhmh/8ODDEsvAwHgMKMIDnGL0x7gJQCAwMAJd4MFwAAAHjaY2BgYGaA4DAGRgYQkAHyGMF8NgYrIM3JIAGVYYDT+AEjAwuDFpBmA9KMDEwMCh9i/v8H8sH0/4dQc1iAmAkALaUKLgAAAHjaTY9LDsIgEIbtgqHUPpDi3gPoBVyRTmTddOmqTXThEXqrob2gQ1FjwpDvfwCBdmdXC5AVKFu3e5MfNFJ29KTQT48Ob9/lqYwOGZxeUelN2U2R6+cArgtCJpauW7UQBqnFkUsjAY/kOU1cP+DAgvxwn1chZDwUbd6CFimGXwzwF6tPbFIcjEl+vvmM/byA48e6tWrKArm4ZJlCbdsrxksL1AwWn/yBSJKpYbq8AXaaTb8AAHja28jAwOC00ZrBeQNDQOWO//sdBBgYGRiYWYAEELEwMTE4uzo5Zzo5b2BxdnFOcALxNjA6b2ByTswC8jYwg0VlNuoCTWAMqNzMzsoK1rEhNqByEyerg5PMJlYuVueETKcd/89uBpnpvIEVomeHLoMsAAe1Id4AAAAAAAB42oWQT07CQBTGv0JBhagk7HQzKxca2sJCE1hDt4QF+9JOS0nbaaYDCQfwCJ7Au3AHj+LO13FMmm6cl7785vven0kBjHCBhfpYuNa5Ph1c0e2Xu3jEvWG7UdPDLZ4N92nOm+EBXuAbHmIMSRMs+4aUEd4Nd3CHD8NdvOLTsA2GL8M9PODbcL+hD7C1xoaHeLJSEao0FEW14ckxC+TU8TxvsY6X0eLPmRhry2WVioLpkrbp84LLQPGI7c6sOiUzpWIWS5GzlSgUzzLBSikOPFTOXqly7rqx0Z1Q5BAIoZBSFihQYQOOBEdkCOgXTOHA07HAGjGWiIjaPZNW13/+lm6S9FT7rLHFJ6fQbkATOG1j2OFMucKJJsxIVfQORl+9Jyda6Sl1dUYhSCm1dyClfoeDve4qMYdLEbfqHf3O/AdDumsjAAB42mNgYoAAZQYjBmyAGYQZmdhL8zLdDEydARfoAqIAAAABAAMABwAKABMAB///AA8AAQAAAAAAAAAAAAAAAAABAAAAAA==) format('woff');
+}
+body {
+-webkit-text-size-adjust: 100%;
+text-size-adjust: 100%;
+color: #333;
+font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+font-size: 16px;
+line-height: 1.6;
+word-wrap: break-word;
+}
+a {
+background-color: transparent;
+}
+a:active,
+a:hover {
+outline: 0;
+}
+strong {
+font-weight: bold;
+}
+h1 {
+font-size: 2em;
+margin: 0.67em 0;
+}
+img {
+border: 0;
+}
+hr {
+box-sizing: content-box;
+height: 0;
+}
+pre {
+overflow: auto;
+}
+code,
+kbd,
+pre {
+font-family: monospace, monospace;
+font-size: 1em;
+}
+input {
+color: inherit;
+font: inherit;
+margin: 0;
+}
+html input[disabled] {
+cursor: default;
+}
+input {
+line-height: normal;
+}
+input[type="checkbox"] {
+box-sizing: border-box;
+padding: 0;
+}
+table {
+border-collapse: collapse;
+border-spacing: 0;
+}
+td,
+th {
+padding: 0;
+}
+* {
+box-sizing: border-box;
+}
+input {
+font: 13px / 1.4 Helvetica, arial, nimbussansl, liberationsans, freesans, clean, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+}
+a {
+color: #4078c0;
+text-decoration: none;
+}
+a:hover,
+a:active {
+text-decoration: underline;
+}
+hr {
+height: 0;
+margin: 15px 0;
+overflow: hidden;
+background: transparent;
+border: 0;
+border-bottom: 1px solid #ddd;
+}
+hr:before {
+display: table;
+content: "";
+}
+hr:after {
+display: table;
+clear: both;
+content: "";
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+margin-top: 15px;
+margin-bottom: 15px;
+line-height: 1.1;
+}
+h1 {
+font-size: 30px;
+}
+h2 {
+font-size: 21px;
+}
+h3 {
+font-size: 16px;
+}
+h4 {
+font-size: 14px;
+}
+h5 {
+font-size: 12px;
+}
+h6 {
+font-size: 11px;
+}
+blockquote {
+margin: 0;
+}
+ul,
+ol {
+padding: 0;
+margin-top: 0;
+margin-bottom: 0;
+}
+ol ol,
+ul ol {
+list-style-type: lower-roman;
+}
+ul ul ol,
+ul ol ol,
+ol ul ol,
+ol ol ol {
+list-style-type: lower-alpha;
+}
+dd {
+margin-left: 0;
+}
+code {
+font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+font-size: 12px;
+}
+pre {
+margin-top: 0;
+margin-bottom: 0;
+font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+.select::-ms-expand {
+opacity: 0;
+}
+.octicon {
+font: normal normal normal 16px/1 octicons-link;
+display: inline-block;
+text-decoration: none;
+text-rendering: auto;
+-webkit-font-smoothing: antialiased;
+-moz-osx-font-smoothing: grayscale;
+-webkit-user-select: none;
+-moz-user-select: none;
+-ms-user-select: none;
+user-select: none;
+}
+.octicon-link:before {
+content: '\f05c';
+}
+.markdown-body:before {
+display: table;
+content: "";
+}
+.markdown-body:after {
+display: table;
+clear: both;
+content: "";
+}
+.markdown-body>*:first-child {
+margin-top: 0 !important;
+}
+.markdown-body>*:last-child {
+margin-bottom: 0 !important;
+}
+a:not([href]) {
+color: inherit;
+text-decoration: none;
+}
+.anchor {
+display: inline-block;
+padding-right: 2px;
+margin-left: -18px;
+}
+.anchor:focus {
+outline: none;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+margin-top: 1em;
+margin-bottom: 16px;
+font-weight: bold;
+line-height: 1.4;
+}
+h1 .octicon-link,
+h2 .octicon-link,
+h3 .octicon-link,
+h4 .octicon-link,
+h5 .octicon-link,
+h6 .octicon-link {
+color: #000;
+vertical-align: middle;
+visibility: hidden;
+}
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
+text-decoration: none;
+}
+h1:hover .anchor .octicon-link,
+h2:hover .anchor .octicon-link,
+h3:hover .anchor .octicon-link,
+h4:hover .anchor .octicon-link,
+h5:hover .anchor .octicon-link,
+h6:hover .anchor .octicon-link {
+visibility: visible;
+}
+h1 {
+padding-bottom: 0.3em;
+font-size: 2.25em;
+line-height: 1.2;
+border-bottom: 1px solid #eee;
+}
+h1 .anchor {
+line-height: 1;
+}
+h2 {
+padding-bottom: 0.3em;
+font-size: 1.75em;
+line-height: 1.225;
+border-bottom: 1px solid #eee;
+}
+h2 .anchor {
+line-height: 1;
+}
+h3 {
+font-size: 1.5em;
+line-height: 1.43;
+}
+h3 .anchor {
+line-height: 1.2;
+}
+h4 {
+font-size: 1.25em;
+}
+h4 .anchor {
+line-height: 1.2;
+}
+h5 {
+font-size: 1em;
+}
+h5 .anchor {
+line-height: 1.1;
+}
+h6 {
+font-size: 1em;
+color: #777;
+}
+h6 .anchor {
+line-height: 1.1;
+}
+p,
+blockquote,
+ul,
+ol,
+dl,
+table,
+pre {
+margin-top: 0;
+margin-bottom: 16px;
+}
+hr {
+height: 4px;
+padding: 0;
+margin: 16px 0;
+background-color: #e7e7e7;
+border: 0 none;
+}
+ul,
+ol {
+padding-left: 2em;
+}
+ul ul,
+ul ol,
+ol ol,
+ol ul {
+margin-top: 0;
+margin-bottom: 0;
+}
+li>p {
+margin-top: 16px;
+}
+dl {
+padding: 0;
+}
+dl dt {
+padding: 0;
+margin-top: 16px;
+font-size: 1em;
+font-style: italic;
+font-weight: bold;
+}
+dl dd {
+padding: 0 16px;
+margin-bottom: 16px;
+}
+blockquote {
+padding: 0 15px;
+color: #777;
+border-left: 4px solid #ddd;
+}
+blockquote>:first-child {
+margin-top: 0;
+}
+blockquote>:last-child {
+margin-bottom: 0;
+}
+table {
+display: block;
+width: 100%;
+overflow: auto;
+word-break: normal;
+word-break: keep-all;
+}
+table th {
+font-weight: bold;
+}
+table th,
+table td {
+padding: 6px 13px;
+border: 1px solid #ddd;
+}
+table tr {
+background-color: #fff;
+border-top: 1px solid #ccc;
+}
+table tr:nth-child(2n) {
+background-color: #f8f8f8;
+}
+img {
+max-width: 100%;
+box-sizing: content-box;
+background-color: #fff;
+}
+code {
+padding: 0;
+padding-top: 0.2em;
+padding-bottom: 0.2em;
+margin: 0;
+font-size: 85%;
+background-color: rgba(0,0,0,0.04);
+border-radius: 3px;
+}
+code:before,
+code:after {
+letter-spacing: -0.2em;
+content: "\00a0";
+}
+pre>code {
+padding: 0;
+margin: 0;
+font-size: 100%;
+word-break: normal;
+white-space: pre;
+background: transparent;
+border: 0;
+}
+.highlight {
+margin-bottom: 16px;
+}
+.highlight pre,
+pre {
+padding: 16px;
+overflow: auto;
+font-size: 85%;
+line-height: 1.45;
+background-color: #f7f7f7;
+border-radius: 3px;
+}
+.highlight pre {
+margin-bottom: 0;
+word-break: normal;
+}
+pre {
+word-wrap: normal;
+}
+pre code {
+display: inline;
+max-width: initial;
+padding: 0;
+margin: 0;
+overflow: initial;
+line-height: inherit;
+word-wrap: normal;
+background-color: transparent;
+border: 0;
+}
+pre code:before,
+pre code:after {
+content: normal;
+}
+kbd {
+display: inline-block;
+padding: 3px 5px;
+font-size: 11px;
+line-height: 10px;
+color: #555;
+vertical-align: middle;
+background-color: #fcfcfc;
+border: solid 1px #ccc;
+border-bottom-color: #bbb;
+border-radius: 3px;
+box-shadow: inset 0 -1px 0 #bbb;
+}
+.pl-c {
+color: #969896;
+}
+.pl-c1,
+.pl-s .pl-v {
+color: #0086b3;
+}
+.pl-e,
+.pl-en {
+color: #795da3;
+}
+.pl-s .pl-s1,
+.pl-smi {
+color: #333;
+}
+.pl-ent {
+color: #63a35c;
+}
+.pl-k {
+color: #a71d5d;
+}
+.pl-pds,
+.pl-s,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sra,
+.pl-sr .pl-sre {
+color: #183691;
+}
+.pl-v {
+color: #ed6a43;
+}
+.pl-id {
+color: #b52a1d;
+}
+.pl-ii {
+background-color: #b52a1d;
+color: #f8f8f8;
+}
+.pl-sr .pl-cce {
+color: #63a35c;
+font-weight: bold;
+}
+.pl-ml {
+color: #693a17;
+}
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
+color: #1d3e81;
+font-weight: bold;
+}
+.pl-mq {
+color: #008080;
+}
+.pl-mi {
+color: #333;
+font-style: italic;
+}
+.pl-mb {
+color: #333;
+font-weight: bold;
+}
+.pl-md {
+background-color: #ffecec;
+color: #bd2c00;
+}
+.pl-mi1 {
+background-color: #eaffea;
+color: #55a532;
+}
+.pl-mdr {
+color: #795da3;
+font-weight: bold;
+}
+.pl-mo {
+color: #1d3e81;
+}
+kbd {
+display: inline-block;
+padding: 3px 5px;
+font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+line-height: 10px;
+color: #555;
+vertical-align: middle;
+background-color: #fcfcfc;
+border: solid 1px #ccc;
+border-bottom-color: #bbb;
+border-radius: 3px;
+box-shadow: inset 0 -1px 0 #bbb;
+}
+.task-list-item {
+list-style-type: none;
+}
+.task-list-item+.task-list-item {
+margin-top: 3px;
+}
+.task-list-item input {
+margin: 0 0.35em 0.25em -1.6em;
+vertical-align: middle;
+}
+:checked+.radio-label {
+z-index: 1;
+position: relative;
+border-color: #4078c0;
+}
+.sourceLine {
+display: inline-block;
+}
+code .kw { color: #000000; }
+code .dt { color: #ed6a43; }
+code .dv { color: #009999; }
+code .bn { color: #009999; }
+code .fl { color: #009999; }
+code .ch { color: #009999; }
+code .st { color: #183691; }
+code .co { color: #969896; }
+code .ot { color: #0086b3; }
+code .al { color: #a61717; }
+code .fu { color: #63a35c; }
+code .er { color: #a61717; background-color: #e3d2d2; }
+code .wa { color: #000000; }
+code .cn { color: #008080; }
+code .sc { color: #008080; }
+code .vs { color: #183691; }
+code .ss { color: #183691; }
+code .im { color: #000000; }
+code .va {color: #008080; }
+code .cf { color: #000000; }
+code .op { color: #000000; }
+code .bu { color: #000000; }
+code .ex { color: #000000; }
+code .pp { color: #999999; }
+code .at { color: #008080; }
+code .do { color: #969896; }
+code .an { color: #008080; }
+code .cv { color: #008080; }
+code .in { color: #008080; }
+</style>
+<style>
+body {
+  box-sizing: border-box;
+  min-width: 200px;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 45px;
+  padding-top: 0px;
+}
+</style>
+
+</head>
+
+<body>
+
+<h1 id="introduction-to-diversity-estimation">Introduction to diversity estimation</h1>
+<p>Amy Willis 2021-10-21</p>
+<p><code>breakaway</code> is a package for estimating species richness. This vignette will lead you through how species richness estimation works, how to get an estimate of species richness using <code>breakaway</code>.</p>
+<p>We will also talk about diagnosing and fixing model misspecification.</p>
+<h2 id="preliminaries">Preliminaries</h2>
+<p>Download the latest version of the package from github.</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb1-1" data-line-number="1"><span class="co"># install.packages(&quot;remotes&quot;)</span></a>
+<a class="sourceLine" id="cb1-2" data-line-number="2"><span class="co"># remotes::install_github(&quot;adw96/breakaway&quot;)</span></a>
+<a class="sourceLine" id="cb1-3" data-line-number="3"><span class="kw">library</span>(breakaway)</a></code></pre></div>
+<p>Note that we are not continuing to maintain the CRAN version of <code>breakaway</code> at this time, so avoid <code>install.packages(&quot;breakaway&quot;)</code>.</p>
+<p>If you are not accustomed to using the pipe in <code>R</code> (the operator <code>%&gt;%</code>), I strongly encourage you to start using it. It will make your code easier to read and write. Here is how to install and load it:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" data-line-number="1"><span class="co"># install.packages(&quot;magrittr&quot;)</span></a>
+<a class="sourceLine" id="cb2-2" data-line-number="2"><span class="kw">library</span>(magrittr)</a></code></pre></div>
+<h2 id="why-bother-with-species-richness-estimation?">Why bother with species richness estimation?</h2>
+<p>Typically, when you sample species (or groups) from a population, you won’t see every <em>individual</em> in the population. This means that you may not see every <em>species</em> in the population. The species richness that you observed in your sample will generally be lower than the species richness in your population.</p>
+<p>The best way to correct this issue is to estimate the number of species that are present in your population but missing from the sample. <code>breakaway</code> provides software to do this.</p>
+<p>Sometimes modeling observed richness is fine and doesn’t cause a problem for modeling or inference. However, <em>especially</em> when some populations are sampled more intensively than others (e.g., your sequencing depth is higher in some samples than others), samples should not be directly compared without adjustment. We recommend getting into the habit of estimating the number of missing species before making conclusions about diversity.</p>
+<p>Note that while this problem has been called “species richness” for historical reasons, you can also estimate the richness at the level of strain (or sub-species), genus, family, etc. The input data that you provide determines the taxonomic order on which <code>breakaway</code> estimates the richness. Therefore, if you would like to estimate strain richness, simply give <code>breakaway</code> abundance data at the strain level. <code>phyloseq</code> has a nice function called <code>tax_glom()</code> that can help with this.</p>
+<h2 id="how-does-species-richness-estimation-work?">How does species richness estimation work?</h2>
+<p>Species richness estimates use the structure of the data that you observed to predict how many species were missing. Essentially, if there are only a few species in the sample that were observed rarely, that suggests that you probably observed most of the diversity in the community. In this case, the total species richness estimate would be close to the observed species richness. Alternatively, if there were many species in the sample that were observed infrequently (such as once or twice), this suggests that there were many species that were observed zero times. In this case, the species richness estimate would be larger than the observed species richness. <code>breakaway</code> uses statistical models to determine how much larger it should be.</p>
+<h2 id="estimating-the-diversity-of-human-host-associated-microbes">Estimating the diversity of human host associated microbes</h2>
+<p>In their very cool paper “Extensive Unexplored Human Microbiome Diversity Revealed by Over 150,000 Genomes from Metagenomes Spanning Age, Geography, and Lifestyle” (<a href="https://doi.org/10.1016/j.cell.2019.01.001">doi.org/10.1016/j.cell.2019.01.001</a>), Pasolli and co-authors assembled 4,930 species-level genome bins using publicly available shotgun metagenomic data. Our goal is to estimate the species-level diversity of human host associated microbes.</p>
+<p>First, let’s read in the data:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="co"># install.packages(&quot;openxlsx&quot;)</span></a>
+<a class="sourceLine" id="cb3-2" data-line-number="2">pasolli_et_al &lt;-<span class="st"> </span>openxlsx<span class="op">::</span><span class="kw">read.xlsx</span>(<span class="st">&quot;https://ars.els-cdn.com/content/image/1-s2.0-S0092867419300017-mmc4.xlsx&quot;</span>, <span class="dt">sheet =</span> <span class="dv">2</span>)</a></code></pre></div>
+<p>The “frequency count table” is the basic data structure for estimating species richness. It is a table with two columns: the second column indicates the number of species observed <code>j</code> times, where the first column contains <code>j</code>. Let’s take a look at the first 10 columns of the frequency count table for the Pasolli et al dataset:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb4-1" data-line-number="1">ft &lt;-<span class="st"> </span>pasolli_et_al<span class="op">$</span><span class="st">`</span><span class="dt">#.Samples</span><span class="st">`</span> <span class="op">%&gt;%</span><span class="st"> </span>make_frequency_count_table</a>
+<a class="sourceLine" id="cb4-2" data-line-number="2">ft <span class="op">%&gt;%</span><span class="st"> </span><span class="kw">head</span>(<span class="dv">10</span>)</a></code></pre></div>
+<pre><code>##    Var1 Freq
+## 1     1 1972
+## 2     2  692
+## 3     3  338
+## 4     4  224
+## 5     5  147
+## 6     6  118
+## 7     7  106
+## 8     8   93
+## 9     9   64
+## 10   10   52
+</code></pre>
+<p>So 1972 species were observed once, 692 were observed twice, and 52 were observed ten times.</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb6-1" data-line-number="1">ft <span class="op">%&gt;%</span><span class="st"> </span><span class="kw">tail</span>(<span class="dv">10</span>)</a></code></pre></div>
+<pre><code>##     Var1 Freq
+## 298 1584    1
+## 299 1629    1
+## 300 1805    1
+## 301 1811    1
+## 302 1844    1
+## 303 1925    1
+## 304 2169    1
+## 305 2559    1
+## 306 2983    1
+## 307 3453    1
+</code></pre>
+<p>The common species are at the other end of the frequency count table: the most common species was observed 3453 times. There was only <code>ft[nrow(ft), 2]</code> species observed 3453 times.</p>
+<p>Let’s take a look to see how many species were observed in the dataset:</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb8-1" data-line-number="1">ft <span class="op">%&gt;%</span><span class="st"> </span>sample_richness</a></code></pre></div>
+<pre><code>## Estimate of richness from method Plug-in:
+##   Estimate is 4930
+##  with standard error 0
+##   Confidence interval: (4930, 4930)
+</code></pre>
+<p>Cool! We corroborated the abstract of the paper and saw that 4930 species level genome bins were identified.</p>
+<p>If you’re not accustomed to using <code>%&gt;%</code>, here is a quick demo: <code>argument %&gt;% function</code>. It’s equivalent to executing <code>function(argument)</code>. So essentially we just ran <code>sample_richness(ft)</code>, but we stated the argument first. The pipe operator <code>%&gt;%</code> becomes especially useful when you want to compound multiple functions. <a href="https://www.datacamp.com/community/tutorials/pipe-r-tutorial">Here</a> is a great introduction, and <a href="https://github.com/adw96/biostat561/blob/master/lecture2/lecture2.pdf">here</a> is a lecture I gave to our department’s PhD students about it.</p>
+<h2 id="species-richness-estimation-with-breakaway">Species richness estimation with <code>breakaway</code></h2>
+<p>The simplest way to estimate species richness with <code>breakaway</code> is as follows:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb10-1" data-line-number="1">estimated_richness &lt;-<span class="st"> </span><span class="kw">breakaway</span>(ft)</a>
+<a class="sourceLine" id="cb10-2" data-line-number="2">estimated_richness</a></code></pre></div>
+<pre><code>## Estimate of richness from method breakaway:
+##   Estimate is 7724
+##  with standard error 2495.5
+##   Confidence interval: (4942, 650226)
+</code></pre>
+<p>So <code>breakaway</code> estimates that there are 7724 species level genome bins in the population of human host associated species level genome bins. That’s 2794 more to discover – how exciting!</p>
+<p><code>breakaway</code> also gives an estimate of the standard deviation in the estimate: about 2495. That’s pretty large! If reflects that species richness estimation is a challenging prediction problem. Do not shy away from large standard errors – they remind you that there is a lot of uncertainty in the estimate! When we go to talk about the function <code>betta</code> in another tutorial (stay tuned!) we will see why this is okay. The short answer is that we typically are interested in comparing diversity across multiple samples, and so uncertainty in individual samples doesn’t cause much of a problem.</p>
+<h2 id="investigating-model-misspecification">Investigating model misspecification</h2>
+<p>The method <code>breakaway</code> actually fits a suite of models, and then selects which is the best amongst them. Check out <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/biom.12332">the paper</a> for more details. But how can we diagnose if the model is reasonable?</p>
+<p>First, we need to find out what model was fit:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb12-1" data-line-number="1">estimated_richness<span class="op">$</span>model</a></code></pre></div>
+<pre><code>## [1] &quot;Kemp&quot;
+</code></pre>
+<p>Kemp models were originally described in <a href="https://onlinelibrary.wiley.com/doi/full/10.1111/biom.12332">the breakaway paper</a>. They are based on fitting flexible non-linear models (that have a probabilistic interpretation!) to ratios of contiguous frequency counts. We can therefore investigate model specification by looking at the plot of fitted ratios:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb14-1" data-line-number="1"><span class="kw">plot</span>(estimated_richness)</a></code></pre></div>
+<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqAAAAHgCAYAAAB6jN80AAAEGWlDQ1BrQ0dDb2xvclNwYWNlR2VuZXJpY1JHQgAAOI2NVV1oHFUUPrtzZyMkzlNsNIV0qD8NJQ2TVjShtLp/3d02bpZJNtoi6GT27s6Yyc44M7v9oU9FUHwx6psUxL+3gCAo9Q/bPrQvlQol2tQgKD60+INQ6Ium65k7M5lpurHeZe58853vnnvuuWfvBei5qliWkRQBFpquLRcy4nOHj4g9K5CEh6AXBqFXUR0rXalMAjZPC3e1W99Dwntf2dXd/p+tt0YdFSBxH2Kz5qgLiI8B8KdVy3YBevqRHz/qWh72Yui3MUDEL3q44WPXw3M+fo1pZuQs4tOIBVVTaoiXEI/MxfhGDPsxsNZfoE1q66ro5aJim3XdoLFw72H+n23BaIXzbcOnz5mfPoTvYVz7KzUl5+FRxEuqkp9G/Ajia219thzg25abkRE/BpDc3pqvphHvRFys2weqvp+krbWKIX7nhDbzLOItiM8358pTwdirqpPFnMF2xLc1WvLyOwTAibpbmvHHcvttU57y5+XqNZrLe3lE/Pq8eUj2fXKfOe3pfOjzhJYtB/yll5SDFcSDiH+hRkH25+L+sdxKEAMZahrlSX8ukqMOWy/jXW2m6M9LDBc31B9LFuv6gVKg/0Szi3KAr1kGq1GMjU/aLbnq6/lRxc4XfJ98hTargX++DbMJBSiYMIe9Ck1YAxFkKEAG3xbYaKmDDgYyFK0UGYpfoWYXG+fAPPI6tJnNwb7ClP7IyF+D+bjOtCpkhz6CFrIa/I6sFtNl8auFXGMTP34sNwI/JhkgEtmDz14ySfaRcTIBInmKPE32kxyyE2Tv+thKbEVePDfW/byMM1Kmm0XdObS7oGD/MypMXFPXrCwOtoYjyyn7BV29/MZfsVzpLDdRtuIZnbpXzvlf+ev8MvYr/Gqk4H/kV/G3csdazLuyTMPsbFhzd1UabQbjFvDRmcWJxR3zcfHkVw9GfpbJmeev9F08WW8uDkaslwX6avlWGU6NRKz0g/SHtCy9J30o/ca9zX3Kfc19zn3BXQKRO8ud477hLnAfc1/G9mrzGlrfexZ5GLdn6ZZrrEohI2wVHhZywjbhUWEy8icMCGNCUdiBlq3r+xafL549HQ5jH+an+1y+LlYBifuxAvRN/lVVVOlwlCkdVm9NOL5BE4wkQ2SMlDZU97hX86EilU/lUmkQUztTE6mx1EEPh7OmdqBtAvv8HdWpbrJS6tJj3n0CWdM6busNzRV3S9KTYhqvNiqWmuroiKgYhshMjmhTh9ptWhsF7970j/SbMrsPE1suR5z7DMC+P/Hs+y7ijrQAlhyAgccjbhjPygfeBTjzhNqy28EdkUh8C+DU9+z2v/oyeH791OncxHOs5y2AtTc7nb/f73TWPkD/qwBnjX8BoJ98VQNcC+8AAAA4ZVhJZk1NACoAAAAIAAGHaQAEAAAAAQAAABoAAAAAAAKgAgAEAAAAAQAAAqCgAwAEAAAAAQAAAeAAAAAAEl/b3AAAQABJREFUeAHsnQd8FMXbx5/0hBaqgPSmIFWaiFIsgKKAXRQVRCzYC3aKWBAFQV9RaSLCH1DAigoWQMEGiID0DtJbAoGQnnvnN7jH3uWS3OXuks3eb/iE252dnfKdud3nnnnmmTCHCsJAAiRAAiRAAiRAAiRAAoVEILyQymExJEACJEACJEACJEACJKAJUADlQCABEiABEiABEiABEihUAhRACxU3CyMBEiABEiABEiABEqAAyjFAAiRAAiRAAiRAAiRQqAQogBYqbhZGAiRAAiRAAiRAAiRAAZRjgARIgARIgARIgARIoFAJWFYAPXLkiNx///0ufwMHDpRnnnlGxo4dK//++68LqBdffFEmTJjgEuftydGjR71Nmm+6w4cPy+OPPy6XXnqp3HTTTfmmL2gCc53//vtvzWnnzp0Fzc5y93311Ve6TdnZ2XnWzZ23JxZmVkZmnuKMa75+eltXX/PNLb0/Yz23PIMRP27cOHn00Uc9Zn3s2DF55JFH5MEHH5R9+/Z5TMNIkYKOreIyRtjHJEACIUwAfkCtGLZu3Qr/pI7SpUs7qlev7vwrU6aMjg8PD3eMHz/eWfXatWs7brzxRue5twfqAe+oWLGit8nzTXfNNdc4IiMjHVdddZVj0KBB+aYvSAL3Os+ZM0cz+fPPPwuSnSXveeGFF3SbMjIy8qyfO293Fu6skJmnuDwLyeeit3XNJxuvLxd0rHtdQIASdu/e3VGyZMkcuSnh39G8eXP9PZk5c2aO64w4S6CgY6u4jJGzLeURCZBAqBGItLrs/fDDD8uIESNcqrl+/Xq5/vrrBdeuvvpqqVmzpst1X05+/vlnOX78uC+35Jl22bJl0q1bN/nmm2/yTOfPRfc6d+nSRdasWSMNGjTwJ9tiea877xMnTriwcGeFRnqKK5aNL4aVhubziiuukA0bNsinn34qN9xwQzFsBatMAiRAAiTgLwHLTsHn1bDGjRvLY489JpmZmfLrr7/mlVQOHDggP/74o0BQSU5OdkmL6dukpCQdt2vXLklMTHS57n6Snp4uq1atkvnz5wvSm8Pp06d1HPKrVKmSPnYvz0iPKUeUderUKVm8eLGcPHnSuKQ/Dx48qIWkhQsXyp49e1yueapzVFSUKM2wREREuKTNq77mhJs3b5Zvv/1Wty0lJcV8Kc/jvOqJG4124hgmE99//30ObriGoH75CabP//rrL92vZ2Jz/z833mYWnlh5ijOXkpCQoPtEaZMFZXgKvtY1NTVVtxv97R7w42eXGktmU4P8uLrnsXfvXoHJintAvu4/rrKysrTwt2DBAl2u+z3GeX5jAuPS16lzQ/jctGmTfPHFF7kKn3n1Ab5TaBf6AFyXLFkiyM8cUPfly5ebo/SxcS9Y44cKvl/etsE8llH+okWL9PfXKAR547uMunsK3n4XvR1beTHyVD7i8JxZunSpfh5izDCQAAmQQJESUA88SwZjCv7555/3WL8PPvhAT9FOnDhRX3efclLCg6N///6OsLAwhxLMdFpM5xvpcVOvXr10vOoA/ansSz2WhcgffvjBgTKQ1sjvyiuvdKgXsb5HaXNc8kK6WbNmecyvfv36joceesjRqFEjfc8555zjwFTz/v37HZi2xL0wMTDqpbS9DvWy1Xl5qrP7tDMS5ldfpFEvTQfaYG5TfHy8A23JK3hTT9yP9ikbPwfqb7QFn3369NHtNcpQgqmjSpUqznafd955jltvvVWf5zYFnxtvMwtPrDzFoR5KQHA899xzmjvYY9zA3GPatGlGNfVnQeqqhAVHTEyM7nOXzNRJ165dHUpzraO95eo+1t3PkRnaA9bm78/KlSsdDRs21PHGGIapiBJ4dfn4z9sxUblyZQf6Ka9gnoI3pt1LlCihx6an+7zpA6PfP/nkEwfyMsZVhw4dHCijY8eOzri6des61I9FZ1HGve+9955D/VBxYKzj/rZt2zqUAO9M5+nAGMtqxsWZP0xt5s2b55g9e7YjOjpax+MTY1f9OHZm4813EYm9GVveMEJe7mMC3wvDfMnoe5ivqB8FSM5AAiRAAoVOAJoES4a8BFAIY7Ahg5Dwzz//6Pq7P3CVhlS/ZGAnCmFUab4c/fr10y8J2AAiKG2l44EHHtC2aHh54eXrKezevVs/vC+55BKH0q5o4UlpkBwQHFu3bu1QWiVHWlqafgFC0Ljvvvv0MeI8BQigeFH17NlTC6nTp0/XyWDDGhsb60DeqMvGjRu1EI2X5Mcff6zTeKqzWehCIm/qi3TDhw/XbcdLGky3bNniUIuntN2e0pYgicfgTT1xI17aeElD6FOaKofSujj69u2r+2Du3Lk6723btjnKlSvnwMsQghDKVQsonC/53ATQ3HibWXhi5SkOFQELQ2ADP6WhdigTDx2HuiMUtK64F0IJbI0hQBgBAieEgddee01HecvVfay7nyMzdwEUgkaFChUczZo10zawuI52VatWzaGmxI0qeT0mwObpp5923ufpwBBADeETfN9//31PSXWcN31gCJH4Mam0qPpH27PPPqv7qWzZsvr7gu8NhO2qVas61GyJszzjXgiealZEx69du9ZRq1Ytx2WXXeYiNDpv+u8AYxl9dfPNNzvwbPrtt98cEHBRD/CfMWOG49ChQ9ruG+3EOETw9rvo7djyhhHKNY8JNavhiIuLcyhzB10fPA+nTp2qmQ0bNgzJGUiABEig0AlYXgCFoDlgwAD9d8899ziuu+46/WLBQx7aNSOYH7h4sUM4hZbRHKCVOP/88x1NmjRxRj/xxBNaSHJGeDiAkArB0tB2GkkgOKIehjCFeKRTK3+NJB4/IYBCG2EWeCHEYtGSeWEVbkaZKANCmRHc62wWupDG2/pCIIdQZNb+QMCGRkdN3RrFuXz6Uk+8tCH04IVnBAiZaI+hmYMQg5cjfiCYQ5s2bXS63ARQI607b3cW7qxwn3ucmo7Vdbj44ouNbPUnygYfCCcI/tQVPyrQbmjMjDB69GitcUUf+8LVPNaRl/s54twF0MGDB+vyoWUzh7ffflvH//LLLzq6IGPCnJ/5GAIo+gffYQiHGPP16tVzgLd78LYPDCHSENqRD34sQGuNcWT+TikvGvpHKNgiGPe+/vrr+tz4DzMV6BsIlbkFjGXU3zyWMY5wn1mIUyY/Ou7ll1/WWXn7XfRmbHnLCAWbx4QyGdB1eumll1yah++5MlVwieMJCZAACRQWAcsvQoJrIcOOTQmVorSOoqbbpHfv3nohknoB5AhYpKQAinoBulxTGgy9QEhNwYl6QYvSQrpcz+1EaUlEaY5ErcZ3SaK0dvocC4CU9srlWn4nShAWNYXoTKZeoDJq1Chd7x07dmg7PdiywRYRAfZu3gZv66u0cqKEaFECsaipWP0HZkrLk2tRvtYT7VSCgTM/NXUrsNM07CHBDja9sJs1ByzkWrFihTkqaMfgDNtXjC0lkLmUozSEorTsOs6fumKhGMaP0pTJtddeq/NT0/tixCMiUP2vM3f7D/a1Srsu+G5gAZARYG+KgDaq6WspyJgw8vL0qTTVAntD2EyuW7dO7rrrLu1eSwl9Lsm97QPjJvUj0jgUJdyK+qEjaird5TuFMaV+RGibYvN33f250KlTJ50X7Lvbt2/vzNf9QAnPLmMZ3xsEoz9xbIxjw5ba2++iN2PLV0aoD4LS8IqavRElgMrXX3+tF25i8SaeWfg+M5AACZBAURCwvACqtJg5VsHnB8owsIdA4R7wglAaEb34SGm33C97PEd+5heekUhNHYuaYhYsrvA1qOnBHLdgsRT8IqrpOC0cK62LFgqQEAK1t8Hb+kLo/Omnn+Stt97SLyalIdILme6991555513chXQfaknGLkHvPSM9mBBR506ddyTCATVwgrGeFm9erWo6dUcxSr7VP0DwJ+6os3K/EDGjBmjF4PghxWEPuVmx1meL1ydN+VyYPA1LqON+AE3efJkI8r5ecEFFwgERYSCjglnZm4H+H5gcU7Tpk3lwgsv1N4hlP2mXgmvZjacqb3tA+MG9Il7gBBqDmivp+A+tsqXL6+TGXXwdA/iPJWJeHO57mUiT2+eHd6MLaN++Y1T/NBwD8oOVZTWWJTWU3/iGIKpcoOVp9Dtng/PSYAESCBQBCwvgBakoTVq1NC3qan4HLdjNSteQN4Kn8gA+XnKS9l8ae0KXq6+BvcXFVZnK/MCgdCppgJF2ZZqARAaqnfffdcpsHlTji/17dy5s+APGlasKEZZygxAWrVqJWYBwSg3kPVEnhB+oPF1D8pu0D0qaOeGZluZeMiQIUNyLcffut5999365f/ll18KNGMQzpV9rC7PH64Qbt015O7jFW2E0Autslnz7qmxvo4JT3kYcWoKXgufxjnG1u+//669WEDbCKYI3vaBkY8/mjuwNguhBitPgqJRHj4LUqa330VvxpavjMx1R59D6MQfvm9wEzd06FCt8VYmIOakPCYBEiCBQiFgy/kXCIR48eHXvjngJY0pKGhijIBpebhlMbvBMa4Zn8oeUWur3N29QGOIYM7PuMfXT7iJUvZl2rcpXszGlKGyzdNZQWtrhPzq7G19IRBh2hXaMmhN1Ips525S0MJ6Cr7U09P97nGoK6aFMb1oDnALFYjgiZV7nFoZLqVKlRJMiZsDplFRP2guEfytK6Zwwfvzzz8XZasqt912m+aOvP3hqmwT9TQ38jGCYbphnKPucMMD90fm8NFHHwnqZbgtKsiYMOeX3zGEbrWgTps8YLrfmKr2tg/yy9+b68oO1yXZZ599ps/xoy/QAdyh6c7v2eHN2CooI7g2wywDnn0IavGU3qEK/OGmzjCHCXTbmR8JkAAJ5EXAlgIopt7Vgh49vYQpTghTalWs1jAqQ37BNnVGUCtitfCpFoRoH5RGvPlTLZgRtdpV348pa7WyVSZNmqTzgSPtQLy44EQeWlHkC1s0aGXUSlWBVg4CE4QHI+RXZ2/ri61C4Rfwqaee0j44IbRgq1PUw2zXZpSLT1/qab4vt2OYHMCWDvZo8OmKvkIcGAQieGLlHoe+heYTZffo0UMwXQkWEDxhO4n6IASirhDwIAhgyrVfv346X/znD1doLGFDiH5HfTHNjm0uzba3Tz75pJ5CRl+/+uqrWiCCIIhtY6F1h/0kgrdjAprb22+/Xd/j63+XX365qAU82iYU5SN42we+luUpPTa2gOCN7zG+Y7CNRD1grxzo4O130ZuxVVBGmM2A6ZFa6CQwf9i+fbu2RVaLJ0UtsNM/vgLdbuZHAiRAAvkSUNovS4a83DB5qnBtt604seJdvWgcSrOlV4AqIc6htAwOZY/mcruajtIrcxUo7a/S5aLpRGnpHFgljXT4Uw90vdocq43NwX1VtvmacYxV8HBN5B6U8OlQ2lRnGWpazqGcZTvgexCrh43gXmf3ld9I52191YvX6cMQ7Tr33HMdSiNkFOXx09t6YuUw3Cu5BzCCGx8joK+VEKW9EaAOF110kV5ZjGN/V8G7s0KZnuKUBtyh7F71am2Ui/EC35JKUDGqqT/9qSsyUNomPSbVdK9Lvjjxlqv7WIeLJfWDQXt+QN3hUxWr3THOlADkLEcJ2HpFv/qBoccY0sGzhLItdKbBgTdjQk1h++QH1KUAdaJmI7RLKNQXq9MRvOkDYyW7MiXQ9xj/4fuoFjgZp/pT/ajQ7TTcoRn3qqln7Z0BZSv7T+0tw1gp75KB6cTTWIY/UeSB8WQE5IM4M3dvv4vejC1vGKEu7mNEaUEdeJ6gbviDGzj454UHAQYSIAESKAoCYShUPZBsGzC1Dts3aAAwVZlbwEIiXMcK7byC8iMpsCHDtKW7HWde9/lyDYsNoL0yL27wdL83dfamvpgGxU5FaL+nxVGeykact/XM7X73eHg7QF18qYN7Hrmde2LlKQ73QzMGbZOxOMVTnsGsa0G5QruPHXI8LeoytwGmHrCFhuY5tzFc0DFhLsefY2/6wNf8YZKDaWfYwbZs2VI/F5SglmMHMV/z9Ta9N99F5OXt2CoII9iUY4yg7w0zH2/rz3QkQAIkEEgCthdAAwmLeZEACRRfAmYBNBBmM8WXBGtOAiRAAkVPwJY2oEWPlTUgARIgARIgARIgARLIjQAF0NzIMJ4ESMBWBLDhARYcKTtnW7WLjSEBEiCB4kiAU/DFsddYZxIgARIgARIgARIoxgSoAS3GnceqkwAJkAAJkAAJkEBxJEABtDj2GutMAiRAAiRAAiRAAsWYAAXQYtx5rDoJkAAJkAAJkAAJFEcCFECLY6+xziRAAiRAAiRAAiRQjAlQAC3GnceqkwAJkAAJkAAJkEBxJBBpxUqr7Rf1jjhWrBvrZB0C2MQrt518rFNL1iQ/AuzH/AjxOgmEJgE837ErHYM9CVhSAF2wYIHMmjVLatSoEXDqau92wQtP7Uce8LytkiHal5mZme+2olapb0HqofbcFvQltiy1c0Ab7bxlIsaq2hdetzEiIsK2XWn3fkTHoR/Rh/ltZ1ycOxnPHQS7j1WrvCP/+usvWbhwYXEeMqx7HgQsKYCivr1795aePXvmUfWCXUpMTBQ8RCpWrFiwDIrBXRA+sd839na3a0D7sPd5lSpVbK0Fxb7dee1JX9z7F2P1yJEjUq5cOYmNjS3uzcm1/njuxMfHS3i4fa2eDh8+rPvQ7s8daOXs/MP3+PHjglnISpUq5TqeC+tC//79C6sollMEBOz7NCwCmCySBEiABEiABEiABEggfwIUQPNnxBQkQAIkQAIkQAIkQAIBJEABNIAwmRUJkAAJkAAJkAAJkED+BCiA5s+IKUiABEiABEiABEiABAJIgAJoAGEyKxIgARIgARIgARIggfwJUADNnxFTkAAJkAAJkAAJkAAJBJAABdAAwmRWJEACJEACJEACJEAC+ROgAJo/I6YgARIgARIgARIgARIIIAEKoAGEyaxIgARIgARIgARIgATyJ0ABNH9GTEECJEACJEACJEACJBBAAhRAAwiTWZEACZAACZAACZAACeRPgAJo/oyYggRIgARIgARIgARIIIAEIgOYV65ZnTp1StatW+dyvV27di7nPCEBEiABEiABEiABEggNAoUigK5YsULGjRsn9evXd1KlAOpEwQMSIAESIAESsAaBpBMSdjpFpFIla9SHtbAtgUIRQLdu3So9e/aUvn372hYkG0YCJEACJEACxZlA2ozpEvHDAoFgkNKkqcQ+9qSERUcX5yax7hYmUGgCKDSeM2fOlAYNGkjr1q0lLCzMBcsvv/ziPN+3b5/68VVJUlNTnXGBOsjOzhb8BSPvQNXR33yysrIkMzPT1m3MyMjQmNCP7mPJX35Wuh99afexCt5Gf1qJfSDrgn5MS0uz9Vh1OBwh8dzB88aOz5zsNaslWwmfxps5a91aOf3VFxLRo1cgvwo+5YV3NYN9CRSaAAqEEEKnTZsmn376qYwePdpJFQ+u++67z3neokULueaaayQxMdEZF+iDYOYd6LoWND+88Owejh8/bvcmBvV7YBV4sBO3ewiFsYpnTig8d5KTk203XKO3bZMYt1al79whqUF8D7sVl+MUihQG+xIoFAF0ypQpUrZsWQkPD5cePXpIr169ZO/evVK9enVNFr8mf/rpJyflpUuXSlxcnNaCOiMDdJCUlCTQRpQrVy5AOVovG7QvJSVFSpUqZb3KBahGaB+ElooVK9pSG2FgOnHihMTHxxuntvvEWE1ISJAyZcpITIz7688+zUU/oo121JwZvXTs2DHdh3Z+7hizEbGxsUazbfOZ3aqVpP8w36U9cc1bSOkitAWNiopyqQ9P7EUg6AJoenq67N69W8qXL6/JRSt7ksqVK8vBgwedAigu1KhRw0m2dOnSAq1oZGTgq2dMnwQjb2cDLHAAYd/ObYyIiNCU0UY7v9TRNjv3o/FVQX/auZ34PqKN+LRrwFi1+3MH7bPtd7JhIwnr219S53wikp4h0VdcKdFduklYEY5ZOz/b7foc8KVdgZfw3ErHL5gxY8bIQw89pKfgN27cKPiljGl2BhIgARIgARIgAWsQiLr8Cklu2UoylOKo9DnnWKNSrIVtCQRdAMUvmMcff1wmTpyo/44cOSLPPfecrbUdth0tbBgJkAAJkID9Caj3NgMJBJtA0AVQNKCVsi2ZMGGChIIdVLA7jPmTAAmQAAmQAAmQQHEnUCgCqAHJzospjDbykwRIgARIgARIgARIIG8C9rWIz7vdvEoCJEACJEACJEACJFBEBCiAFhF4FksCJEACJEACJEACoUqAAmio9jzbTQIkQAIkQAIkQAJFRIACaBGBZ7EkQAIkQAIkQAIkEKoEKICGas+z3SRAAiRAAiRAAiRQRAQogBYReBZLAiRAAiRAAiRAAqFKgAJoqPY8200CJEACJEACJEACRUSAAmgRgWexJEACJEACJEACJBCqBCiAhmrPs90kQAIkQAIkQAIkUEQEKIAWEXgWSwIkQAIkQAIkQAKhSoACaKj2PNtNAiRAAiRAAiRAAkVEgAJoEYFnsSRAAiRAAiRAAiQQqgQogIZqz7PdJEACJEACJEACJFBEBCiAFhF4FksCJEACJEACJEACoUqAAmio9jzbTQIkQAIkQAIkQAJFRIACaBGBZ7EkQAIkQAIkQAIkEKoEKICGas+z3SRAAiRAAiRAAiRQRAQogBYReBZLAiRAAiRAAiRAAqFKgAJoqPY8200CJEACJEACJEACRUSAAmgRgWexJEACJEACJEACJBCqBCiAhmrPs90kQAIkQAIkQAIkUEQEKIAWEXgWSwIkQAIkQAIkQAKhSoACaKj2PNtNAiRAAiRAAiRAAkVEgAJoEYFnsSRAAiRAAiRAAiQQqgQogIZqz7PdJEACJEACJEACJFBEBCiAFhF4FksCJEACJEACJEACoUqAAmio9jzbTQIkQAIkQAIkQAJFRIACaBGBZ7EkQAIkQAIkQAIkEKoEKICGas+z3SRAAiRAAiRAAiRQRAQogBYReBZLAiRAAiRAAiRAAqFKgAJoqPY8200CJEACJEACJEACRUQgsojKzbNYh8MhycnJkpiYmGe6glxMT08X5B+MvAtSn2Dck52dLVlZWfovGPlbIc/MzExdDfRjWFiYFaoUlDpkZGTYfqwC3KlTpyQlJSUoDK2QKZ47x48ft/VYxXMnNTXV9s8dPG/QTrsGPHPQl1Z4RxrPebuyDvV2WVIARaeUKFFC4uPjA94/J06c0A/IYOQd8MoWMEN8afEyL126dAFzsP5taF9SUpIeI3YWQPESsPNYxQ+lo0ePSsmSJSUmJsb6A6+ANcRzB9/H8HD7TjodOXJE96Hdnzt43sTGxhZwJFj/NoxVvEOs8NyJjLSsiGL9jiwGNbRk7xoCRTAf1sHMu6j7HW0DQzu30TxGjOOi5h6M8u3ej9C0INi9nWgjvo92/07avR/RvlBoozFe8clAAsEiYN+f48EixnxJgARIgARIgARIgAT8IkAB1C98vJkESIAESIAESIAESMBXAhRAfSXG9CRAAiRAAiRAAiRAAn4RoADqFz7eTAIkQAIkQAIkQAIk4CsBCqC+EmN6EiABEiABEiABEiABvwhQAPULH28mARIgARIgARIgARLwlQAFUF+JMT0JkAAJkAAJkAAJkIBfBCiA+oWPN5MACZAACZAACZAACfhKgAKor8SYngRIgARIgARIgARIwC8CFED9wsebSYAESIAESIAESIAEfCVAAdRXYkxPAiRAAiRAAiRAAiTgFwEKoH7h480kQAIkQAIkQAIkQAK+EqAA6isxpicBEiABEiABEiABEvCLAAVQv/DxZhIgARIgARIgARIgAV8JUAD1lRjTkwAJkAAJkAAJkAAJ+EWAAqhf+HgzCZAACZAACZAACZCArwQogPpKjOlJgARIgARIgARIgAT8IkAB1C98vJkESIAESIAESIAESMBXAhRAfSXG9CRAAiRAAiRAAiRAAn4RoADqFz7eTAIkQAIkQAIkQAIk4CsBCqC+EmN6EiABEiABEiABEiABvwhQAPULH28mARIgARIgARIgARLwlQAFUF+JMT0JkAAJkAAJkAAJkIBfBCiA+oWPN5MACZAACZAACZAACfhKgAKor8SYngRIgARIgARIgARIwC8CFED9wsebSYAESIAESIAESIAEfCVAAdRXYkxPAiRAAiRAAiRAAiTgFwEKoH7h480kQAIkQAIkQAIkQAK+EqAA6isxpicBEiABEiABEiABEvCLAAVQv/DxZhIgARIgARIgARIgAV8JUAD1lRjTkwAJkAAJkAAJkAAJ+EWAAqhf+HgzCZAACZAACZAACZCArwQKXQBdvHixnDx50td6Mj0JkAAJkAAJkAAJkIBNCBSqALpkyRIZOnSoJCQk2AQfm0ECJEACJEACJEACJOArgUITQI8ePSpTpkyRsmXL+lpHpicBEiABEiABEiABErARgcjCaIvD4ZCRI0fKww8/LG+88YbHIu+55x5nfOnSpaVt27Zy7NgxZ1ygDjIzMwX1CUbegaqjv/mgfdnZ2ZKRkeFvVpa9PysrS9cN/RgWFmbZevpbMfSh3ccqGMEsJzk52V9clr0fz53ExETL1i8QFcN3MiUlxdbPHTxXEU6fPh0IZJbMw0rvSDu/wyzZ+YVcqUIRQOfOnSs1atSQ1q1b59q8yMizVQkPP6OYDaZgEcy8c21kIV+wcxuNtuHTOC5kvIVSnN3bZ4Zo53402mn3NobKeLV7P2K8WqGNVqiD8d3lZ+AJnJX6Ap+3znHnzp0yf/58+eCDD/IsYcKECc7r8+bN01rK8uXLO+MCdQAtBH6pByPvQNXR33zwCxa/0MuUKeNvVpa9H+07ceKE7kc7P6RgL233sXrkyBHBrEdsbKxlx5u/FcNzJz4+Xowf1/7mZ8X7Dx8+rPvQ7s8dPG/i4uKs2AUBqdPx48e1FtsKzx2zYiogjWMmliIQdBvQhQsXyu7du6VHjx7StWtXOXjwoAwYMECWL19uKRCsDAmQAAmQAAmQAAmQQOEQCLoGFMIm/oxw8803y+jRo6VWrVpGFD9JgARIgARIgARIgARCiEDQNaAhxJJNJQESIAESIAESIAES8IJA0DWg7nWYM2eOexTPSYAESIAESIAESIAEQogANaAh1NlsKgmQAAmQAAmQAAlYgQAFUCv0AutAAiRAAiRAAiRAAiFEgAJoCHU2m0oCJEACJEACJEACViBAAdQKvcA6kAAJkAAJkAAJkEAIEaAAGkKdzaaSAAmQAAmQAAmQgBUIUAC1Qi+wDiRAAiRAAiRAAiQQQgQogIZQZ7OpJEACJEACJEACJGAFAhRArdALrAMJkAAJkAAJkAAJhBABCqAh1NlsKgmQAAmQAAmQAAlYgQAFUCv0AutAAiRAAiRAAiRAAiFEgAJoCHU2m0oCJEACJEACJEACViBAAdQKvcA6kAAJkAAJkAAJkEAIEaAAGkKdzaaSAAmQAAmQAAmQgBUIUAC1Qi+wDiRAAiRAAiRAAiQQQgQogIZQZ7OpJEACJEACJEACJGAFAhRArdALrAMJkAAJkAAJkAAJhBABCqAh1NlsKgmQAAmQAAmQAAlYgQAFUCv0AutAAiRAAiRAAiRAAiFEgAJoCHU2m0oCJEACJEACJEACViBAAdQKvcA6kAAJkAAJkAAJkEAIEaAAGkKdzaaSAAmQAAmQAAmQgBUIUAC1Qi+wDiRAAiRAAiRAAiQQQgQogIZQZ7OpJEACJEACJEACJGAFAhRArdALrAMJkAAJkAAJkAAJhBABCqAh1NlsKgmQAAmQAAmQAAlYgQAFUCv0AutAAiRAAiRAAiRAAiFEgAJoCHU2m0oCJEACJEACJEACViBAAdQKvcA6kAAJkAAJkAAJkEAIEaAAGkKdzaaSAAmQAAmQAAmQgBUIUAC1Qi+wDiRAAiRAAoVOIDshQTL/XinZRw4XetkskARCnUBkqANg+0mABEiABEKPQObff0nqB++JpKeLRERITL97JKpjp9ADwRaTQBERsKQA6nA4BH/Z2dlBwxLMvINWaS8zRtuCzc/LqgQtGdqHgLaGhYUFrZyizjhU+tHu7TTGalGPp2CWjz4sLv2IeqZ+9OEZ4RNQsrIkbfpUCW/TRsJiYnPFhPsQ7Pz+CIU25trBvFCoBCwpgIJASkqKJCUlBRxGRkaGfngEI++AV7aAGeLhmKUeqHZuY2ZmpqaDNtpZAEU77dyPxov89OnTkpaWVsARb/3b8Nw5efKkrccqBJd0pU0sFuNV9UcEnh3moaPqfvLgIZFy5cyxLsf4PuJ5g3baNVjpHWk85+3KOtTbZUkBFF/wEiVKSNmyZQPeP4mJiVo4C0beAa9sATPElxYv9DJlyhQwB+vfhvadOHFCjxE7C6AJykbN7mP1yJEjUrJkSYmNzV3zZP0RmXcN8dyJj4+X8HD7mt0fPnxYYmJiis1zJ6XFhZK1epWz48Lr1pWydeo4zz0d4LmD501cXJyny7aIO378uEAItcJzJzLSkiKKLfrZCo2w79PQCnRZBxIgARIgAUsSiL1voER26CRhlStLZNt2EvvYk5asJytFAnYlwJ8Xdu1ZtosESIAESCBXAmHQug+4L9frvEACJBBcAtSABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESIAESCC4BCiABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESIAESCC4BCiABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESIAESCC4BCiABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESIAESCC4BCiABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESIAESCC4BCiABpcvcycBEiABEiABEiABEnAjQAHUDQhPSYAESIAESIAESIAEgkuAAmhw+TJ3EiABEiABEiABEiABNwIUQN2A8JQESIAESIAESMD+BNLT0yU1NdX+DbVoCymAWrRjWC0SIAESIAESIIHgEEhMTJRmzZrJv//+G5wCmGu+BCiA5ouICUiABEiABEiABOxE4Pjx47J582Y7NanYtYUCaLHrMlaYBEiABEiABEigoASSk5Pl+eef17cPHjxYFixYIA899JAsWbLEJcvPP/9cRo0aJRkZGXLvvffK2rVr5eGHH5YePXrI22+/LadOnXJJv3r1ap2ua9eu8vjjj8v+/ftdrvPElQAFUFcePCMBEiABEiABErAxgcjISGnevLluYdOmTaVatWpy8OBBGTNmjEurX3rpJX2elZUlkydPli5dukhKSor07NlTxo0bJ3379hWHw6HTLFq0SC6++GItlN58882ybNkyPcVPIdQFqcsJBVAXHDwhARIgARIgARKwM4GYmBjp3bu3buKtt94qEELvvvtumT9/viQkJOh4aDM3bNggd9xxhxPFVVddJR9++KHWcs6ePVugIf3ll1/09UGDBsnVV18ts2bN0tf/+OMPqVmzpowYMcJ5Pw9cCUS6nvKMBEiABEiABEiABEKLAITL8uXLCwTLBx54QKZNmybdunWTqlWrOlfKQ8A0woUXXiiVKlWSv//+W2s+16xZo9M+99xzRhKJiIiQv/76y3nOA1cChaYBPXz4sLaz2Llzp2sNeEYCJEACJEACJEACRUgA0/J33nmn/O9//xNMuc+cOVP69evnUqNatWo5z8PCwqRs2bJ6yj0pKUmys7OlVKlSEh4e7vzDlP2NN97ovIcHrgQKRQP6zTffyJw5c6RDhw4yffp0uf322+Waa65xrQnPSIAESIAEii8B9dJWBnHFt/5FXHMH+CnhBYKNN8GRmSlhSmhiKBgBg7Nhw4lcIHCOHj1aa0HhIxS2nuYAO8927drpKLhv2rp1q7Rs2VJrQsuUKSPnnnuuy5T7Dz/8IFFRUeYseGwiEHQNKDoXnTB8+HAZMGCAXhn26aefmqrAQxIgARIggeJKwKFWCKdOnihxLzwjYc8OkowlZ2ziimt7CrveDjhDnzheku/pK8kPPSAZvy3NswqZK/+S5EcflOQB/SRl3DviSDmdZ3pe9EwA0+0IK1eulBMnTujjCy64QNq2bStPPvmkthGFrag5YFp++fLlcujQIRkyZIjUr19fOnbsqJMMHDhQK9i+/vprrUHFivpevXrJ0aNHzVnw2EQg6D+f8Cvj//7v/3SRcGXw22+/Se3atU1VOHNonprHYChZsqRkql94gQ4QiPEXjLwDXdeC5oe2YTrAzm3EFAkC2mj8ki0oLyvfFyr9iP6083g1+hHTc3YLmfO+ksylv4jW2ylhKG3KJHHUqCHhNWraralasMDzJpBjNeOrLyTLEDqTT0napAniqK74Vaueg5/j2DFJe3+cevBl6GtZK5ZLqpr2jbqjb460BY2w0jsSdQlWgMYSdp99+vTRAudbb72li8JiJNiAQhvqHtq0aSOdO3fW79cmTZrIt99+K8gHYdiwYXo6/qabbhJM51euXFmefvppwYp4Bs8Egi6AGsXCRgIdDRcGkyZNMqL1JwYZBoIRWrRooafojxw5YkQF/DOYeQe8sgXMEKztHkLh12UojFU8H+wejinhwY4hbt1acXmRqOd50t8rJSM2zo7N1W06efJkwNrmkd+qvyUj2lX7hgIj/1kjcf8Jn0YF0tevl+NBeFda4bkDpVUwA1a9oy9LlCjhLAY/ErEqHppQ99C/f3+9Ch5KMixAMoe4uDjtmmns2LFaQ1q9es4fEOb0PFbj2RcIEBRh9wDXBPHx8QJB0dxxeeWFXwlQTUMtff/998tXX30l6DAE/KKcMmWK8/b16gsFY15DRe68EIADOI6FtgX1t2tA+9LS0rzum+LIAe2DM+Fy5crZWgOKh2Pp0qWLYxd5VWeMVTzM8X2Pjo726p7imAj9iFkdO2pAs+rWk+zt21y6pWTDRhL+3xSny4VifoJ9w/G+cp+a9adZmt+unS5ZlDy/oUd+joYNJVOVb7a1jaxTN6DvSiu9I6FJDHYwnq+YhYV8M3LkSHn22WdzLRbPKXfh05wYNp8UPs1Ecj/2qndhI4HdAn799VetYsYXEMIoXAw0VF+I9u3b610F6tSpk6MkGPLCTQEMd3Ffp06d5L333hMIma1bt3amv+SSS5zH8MOF/AP5JTcyP336dNDyNsoo6k9MD+EvGPyKum1G+RBcENBGjCu7BgjZdu5HYyoTD207txPPHbTPjgKo48abJHXfPsnasE4c6rsYc/2NEt24iS2/knjuBFoAddx0i6Qe2C9ZGzfoRUjRN94s0Y0u8MyvVm3JuLOfpM2cDvsjCa9bV2Jvv0PC3WwVPd/sXSxmzmAyYoXvY2F+X7BQGrsjwS8o1quYA/ocQqedfySb21tYx3kKoLt375YXXnhB4JAVrgTg3wpuCLBrAH4lbdq0Sf/9/vvveiUY7CaQ3vhFgUbgxTJ+/Hj94IVKG3uvYirK7M6gsBrLckiABEiABAJLICyuhMQ9+7wcUc/2mPgyEl2lamALsHluYUozHvfci5J97KiEKbMFnOcVoq64UiKV0sdxKlnC3aaB87qP1/Im8Mwzz8ijjz4qsbGxORJCGIcrSYbAEshVAMUvIPwSwOr1GTNm5CgVU5/Ydgp/MNp99dVX5Z133tG/HMyr3PHLAXuiQgidOHGi/lWFPPNSYecojBEkQAIkQAKWJuBQ7wT19rZ0Ha1cufAKFb2uHoR+/DEEloAn4TOwJTA3M4FcBVCovqHZ9FYFjhVf2HLKmBo1FwJbUQig0JrC1ouBBEiABEiABEiABEggdAnk6RPEW+HTvNoadqG5BQqfuZFhPAmQAAmQAAmQAAmEDoE8BVAzBmxR5cmNyIQJE+TBBx80J+UxCZAACZAACZAACZAACeRKwGsBdMeOHdK8eXP55ZdfdGYwyO3Ro4e278QWmwwkQAIkQAIkQAIkQAIk4A0BrwXQxYsX6z3cu3TpIthyCo5aoRFdtWqVwDkrAwmQAAmQAAmQAAmQAAl4QyDXRUjuN8P/1SuvvCJbtmzRC4rgJB7O4+EHlIEESIAESIAESIAESIAEvCXgtQb0jz/+kAsvvFBWrFghn332mVxxxRXa9+eYMWO001pvC2Q6EiABEiABEiABEiCB0CbgtQDavXt3ady4saxdu1ZuuOEGmT17ttaEwqfnI488EtoU2XoSIAESIAESIAESIAGvCeQpgO5T26sZAU7ksVWVeX/2u+66S9asWSMNGjQwkgkWKzGQAAmQAAmQAAmQAAmQQG4EchVAsRf7ddddp/eAP3TokNx8880e86hdu7Y89thjMm/ePLn00ktl1KhRHtMxkgRIgARIgARIgARIgARAINdFSNhC888//5TJkydrW8/zzjtP233WrFlTatSoIUlJSc694GEfivSwB7366qtJlgRIgARIgARIgARIgARyJZCrBhR3YFej+++/XzZv3ixdu3bVW3MOGTJELr/8cundu7dejIS9U1988UVtG0rhM1fOvEACJEACJEACJEACmsDJkydl1qxZ8vLLL8vXX3+tlXpmNDNmzBCksVrA7DhMMvHpb8hTADUyxxaazz//vHz33Xeye/duDQVgli9fLh988IFgl6TIyFyVqUY2/CQBEiABEiABEiCBYkHAcfq0pH0yU1LeelPSv18gjuzsgNQba2ewsc/nn38uUOJB2Kxfv772q24U8PTTT8vRo0eNU8t8ZisGUEwGQgDNU2p84403pF+/flK5cmXBfu9xcXEaAvd0t8xYYEVIgARIgARIgAQCTAACVsqYUZK9dYvOOeufNeJITJCY3rf7VVJWVpb07dtXnnrqKXnooYececGzEGaR169fLxUqVNDxqMPWrVv14m8jDhcSExNlz549UqdOHSldurQzD6THQnD4bYepJEJGRoaW3/CJ6+Hh4fqeqKgofT0tLU1SU1MlPj5en0PoxU6XMLs0KxaRDgpIlBmokKcGdNiwYbrxKKxq1apy/PjxQJXLfEiABEiABEiABEjAkgSylRcgQ/g0KpixeJFxWOBP+FI/cOCA3lHSnMktt9wi1atXl6VLlzqjb7/9dq0ErFevnrz55ps6fubMmdKqVSsZOnSoNGrUSHCOAKG0Xbt2esF4p06d9CJyCJzLli2Tyy67TPtxx/UnnnhC3n33XX0P/hs8eLBev4NjzHQ3adJEazjh3QjmlwhffvmlnHvuuTJgwABB3oEKeWpAjYrA6TwkZNh6xsTE5CgbqmRI9AwkQAIkQAIkQAIkUNwJhMXF5mhC2H+zwDku+BCB3SQx3Q5NpHto0aKF3uwHHogQ4H8dgiZcYtatW1evvcEOlBBGb7rpJlm5cqVeLI600KBis6Dx48cLtKw9e/YULBBHWLdundaMQpEIARdC6JNPPqk3EYId6pIlS+TIkSPaFABaTsh5H374oc4LZcHl5sKFC6VNmzYydepUZ746cz/+y1MAhV3CiBEj9PabaNDGjRvFUNuayzSrhs3xPCYBEiABEiABEiCB4kYgvEJFieraTTJ++P5M1ZWnn+hbe/vdDPhSx3S2pwBFX8WKFZ2XIGQiVKtWTZo2baoFTphF4m/SpEnSq1cv6dOnj04DP+0IuIaAafS5c+fqjYMgvCIPhI4dO+oFTxs2bNCCLYRhXMfCIkzdw74TITk5WWtPkR/ML1u3bq3jr732Wu31SJ/4+V+eAihUsB9//LEuApI11LBlypTxs0jeTgIkQAIkQAIkQALWJhDT5y6JaNpcsvfvk4hGF0hErdp+V7h9+/ZamYdpeGgkjQChFNpJ886SZi0phFPIZJiZhmYUvtenT5+uF4Jjh0qEbt26SYcOHYwspVy5clqzaV63A5eZECoxdf/vv//K3XffrdNjuh7C6AMPPOC8HwcQSmE/isVH8IyEP3O9XBL7eJJTB/xfBigMi49ggwAhdP78+RQ+fYTL5CRAAiRAAiRAAsWXQGSz5hJ9VfeACJ+gAA3ooEGD5I477tDCIeKwyBuCH2w7DU0j4iFgQhZbvXq1pKena+Hz+uuv19PuMHuEn/adO3dqAfHWW2/VGkvkAVtPbAoEe1NPAfdCO7po0SI9lY80N954o9awYpER7sfip9GjR0vDhg31Sn3IgAi4DzPigQi5CqCQcOEqoEuXLlr4hNQN+4TnnntOFi9erGEEogLMgwRIgARIgARIgARChcDw4cOlc+fO+g9aTSwmgqbxk08+0RpGg8OmTZvk/PPP177XR44cqaMhvGI9zkUXXaR3nxw7dqw2jcQiplOnTklttTsl1uXAjvO2224zsnL5xAp5bCoEjWnJkiX1NUz9wy4Uq99h6/n+++8L6gmN6RdffCEPP/ywNG7cWLuOKlGihEt+BT0JU2pXr7yJQgqH388FCxboP4DBaig0AK4DArk0H6plVAtGtIEOWCkG6d1sZxHoMoo6v8zMTDmt/JfZ2VwC7Ttx4oRUqVIlYPYoRd1vnspPSEjQv5g9XbNDHMYqjN8xVQR/eHYNeO7AzUmgpq6syAk2Z+hDuz938EI2XBJasR/8rRO83WDKtVKlSv5m5ff9/fv3Fyy6sXM4duyY0+2Sp3bi2QFXS2aXSEiHd0PZsmVzPFOwSyWE2YI+T/FMhp93PJPdQ6DfR7lqQN0LxoMTatmXXnpJq3/hawrT81Dx3nPPPe7JeU4CJEACJEACJEACJJAHgfwWcUMQdBc+kR2m8j39oMUPwIIKn8gXZXkSPo0y8RmokOciJPdCoJWE0SpWT+HXfI8ePQR2BwwkQAIkQAIkQAIkQAIk4C0BrzSg8DWFaXZI1rAvuOaaa+SSSy7R57ANve+++7QhrLeFMh0JkAAJkAAJkAAJkEDoEshTAIVDUviYghNSGKV+8803WtCEuwDYAsBlALaTgma0ZcuW2os+bAcYSIAESIAESIAESIAESCA3ArkKoFh0hOl1CJ/Ym/Tll1/Wi46gAYUzetgIXHzxxdqHFByiYlESjLOxVRMDCZAACZAACZAACZAACeRGIFcbUBi3/v777x6NXD1lBp+h2DUpUP6hPJXBOBIgARIgARIgARIggeJPIFcNKJrmaYVVfk2Gl3wGEiABEiABEiABEiABEsiNQJ4CaG43MZ4ESIAESIAESIAESIAECkog1yl4ZDhhwgTt7Du/zOGpv1evXvkl43USIAESIAESIAESIAESkDwF0D/++EPvA48dEWDjmVvAbkgUQHOjw3gSIAESIAESIAESIAEzgTwF0I8++khvWYnN5+FyCds+MZAACZAACZAACZAACZCAPwTytAGFW6WRI0dql0vYgpOBBEiABEiABEiABEiABPwlkKcGFJljX9BPP/1Uli1b5m9ZXt8Px/apqakSDKf2mZmZAh+nwcjb6wYGOSHal5GRYes2on0I6Ef8ULJrwHi1+1hF36WkpOgxa+d+PHXqlK3HKp476enpth6veO7geYPvpV0D2miVd6RV3DpmObIkIowefgI95vMVQFHgeeedp/8CXXhe+cHZfWxsbF5JCnTNEFyCkXeBKhSEmwwh285tBDbsyIU22lkANdoYhGFiiSzxgjl9+rRER0frP0tUKgiVwHMnJiamQK7tglCdoGSJfoQbPrs/d/C8QV/aNWCsQglkhX4siCvIQPfLiYwkeWL1UJnS5u2AZI1n3ocffpgjL8hZnTt3lpkzZ8q1116rtzrHD/O4uDid1nyc4+ZcIrZv3y47duyQLl265JKiaKO9EkCNKh45ckRuueUW+fzzz/W0vBEf6E98wfEggxAa6IC88ReMvANd14Lmh/bhIWLnNho/JNBGtNeuAQ9gO/ej0XfB+r5bZVwYzxwrvFCDxQRttHs/4rlj9GWwOBZ1vhijVmkj6lHUYdSm9+W7Az/JV/sWSK9qV/ldHcwS3H///dKvXz8XId/4UfPJJ59Ix44d5a+//pJp06bJ1KlT9fu8SZMmAoHSl7B8+XLBGh5bCKDQxvz88896msUXCExLAiRAAiRAAiRAAsWJwNaTO+SjXbN0lV/Z8JZ0rdJZ4iICMzP71ltvSfny5XPgwOLvMmXKyJdffqndYCYlJUlycrLs2rVLoASEVyIEmClu27ZNatasqdObMzp06JA2ozDHWfE4z0VIVqww60QCJEACJEACJEACwSYwdP0bAvtPhL0pB+SDbVP1cTD/a9GihaxcuVImTpyo196MHTtWXnvtNS1Q3nXXXdr+eNGiRVK7dm15/PHHpVatWjJlyhRnlQYMGCBt27aVK6+8Ut555x1nvBUPvJqCr1evnra3MwyCL7zwQm3LBJWxryphK0JgnUiABEiABEiABEjAIPDjoV9k8eHfjFP9+e62ydK75nVyblwVl/iCnMDeE4u8jbBixQptwoLzihUryqBBg2T+/PkybNgwvUhz/Pjx+hzXR4wYITNmzJArrrhCoO3ElP3dd98t3377rXaZuXXrVp231f2zn209WpVLgKoYwuexY8e07cIrr7yifYLC3oeBBEiABEiABEiABOxCAFrPMZs/kDKRpXM06Z2tk+SNZkNyxPsaMW7cOImPj3fe5q08hWn4X3/9VduHTp8+Xd+fmJgof/75p9aYwt4TizoRrrnmGvnxxx/1sRX/80oAve6663Td9+7dqz+xQiuvnZGs2FDWiQRIgARIgARIgATyIwCXS/M7fpJfMr+uY1GRJxtQbzKFgImpdmOB6gMPPCD169fXgidsQ41gXDfOrfZJG1Cr9QjrQwIkQAIkQAIkENIE4AYLrpcQDI0mVtBjEdJFF10ku3fvlnbt2ulFSJh+h/vFTp06yYIFCyQhIUGff/bZZ5Zm6JMACq3nmjVrpEKFCpZuFCtHAiRAAiRAAiRAAsWVABYjLVmyRGDHien5Sy+9VKpWraptPocPHy4vvviiNGvWTLp27SpPPPGEVKlSRduCPvjggwLt6vnnn+/UkFqVgVdT8Ebloc5Fg91DQRykuufBcxIgARIgARIgARKwMwE4loej/9zCnj17nJeOHj3qdHsJF5jY7KFEiRLaBBIaULNbJuOmF154QZ566imtAS1ZsqQRbclPrzWgd955p16E5N6KCRMmCCRuBhIgARIobAIONUWVOuF9OTWgnyQ/ox66G9YXdhVYHgmQAAkEhQA2BTDvSAXh0xwMn6DmOBzDQ5HVhU/U02sBFNs5NW/eXH755RfcJ4cPH5YePXpoP1QdOnTQcfyPBEiABAqTQNrsWZL5u3KVgu0DDx2U1HfGSnbSicKsAssiARIgARIoAAGvBdDFixfL7bffrrd0GjhwoDRt2lRrRFetWiX9+/cvQNG8hQRIgAT8I5C1bp1rBqkpku3jdnWuGfCMBEiABEigMAh4bQOKVVjw/7llyxaBQ1S4D4D3/YYNGxZGPVkGCZAACeQgEF6tumQdPnQ2Xu0dHV713LPnPCIBEiABErAkAa81oH/88YdgByR468fSfnjgb9mypYwZM6ZY7DlqSfqsFAmQgF8EYvrcKWGGwKlWikar83C1GpSBBEiABEjA2gS81oB2795d7y2KRUfQft5www3aE/8jjzyit+N87733rN1S1o4ESMB2BMKVT7wSr42U7P37JDy+rISVKWO7NrJBJEACJGBHAnlqQPft2+ds84SSGl0AAEAASURBVMSJE2XOnDkunvvvuusu7Re0QYMGznRYrMRAAiRAAoVFIExpPiNq1KTwWVjAWQ4JkAAJBIBArgIo/FRhC87Bgwdrx6c333yzx+Jq164tjz32mMybN087Sh01apTHdIwkARIgARIgARIgARIgARDIdQo+TBnzY3P7yZMna1vP8847T9t91qxZU2rUqCFJSUmyadMm/Qf7UKSHPejVV19NsiRAAiRAAiRAAiRAAiSQK4FcBVDcge2f7r//funTp4+8++67snTpUpk0aZL8+++/2jkqXDG1atVKbwl12223SWRkntnlWgleIAESIAESIAESIAESCB0CXkmMpUqVkueff17/Ac2pU6e0AEqBM3QGCltKAiRAAiRAAiRAAoEikKsNKAp44403tP0njrHfuxEgkFL4NGjwkwRIgARIgARIgARIwBcCeQqgw4YNk61bt+r8qlatKsePH/clb6YlARIgARIgARIgARIggRwE8pyCb9KkibYBhdP51NRUbeuJTe7dA/aI79u3r3s0z0mABEiABEiABEiABP4jgNnk6dOnO3lApqpTp4506NBBL+Z2XvDxAJ6LsEbn3nvvlWXLlmkzyRYtWuSZC+oSFxenF5zHxsZKfunzzKwAF/MUQGfMmCEjRozQ229mZWXJxo0bJSoqKkcxFSpUyBHHCBIIZQKZGzeI48hhiWjcRMIrVAxlFGw7CZAACRQ7AgcSRGYsca12mDp96jrXOF/PTpw4oRV79913n4SHh0t6erq89tprUrduXfnuu+90nK95In12drbOd8CAAVoAjY+Pz1OgfPzxx6Vjx456UyEIrPmlL0id8rsnTwH0/PPPl48//ljngW04v/zySynDnUbyY8rrIU4gbdpUyVj44xkK0dES+8QgibygcYhTYfNJgARIoPgQSFLLXn7bmLO+/gqgRo7YPdJYS4OF3eecc46sXr1a4F0ImsmMjAyBVrNixYr6E5v8RKv3CdxgmkNaWprs3r1ba1GNeAihcI1pBCgQt2/fLvXq1dPejZD/hg0btICK+93T4z6YX1auXNkp86GOUEBCYN6zZ4/ANadRf6McXz/zFEDNma1atcp8ymMSIAEPBLL27j0rfOK6+rKmfzJTIl9+zUNqRpEACZAACYQ6AQiacHsJBR+0kdjc58iRI1rgXL58ufavDoEU63CaNWsmX3zxhRYwoRS85557pHHjxpKZmenEOHToUMHM9AsvvCC//vqrXH/99VrYhOA4duxYSU5O1sLu0aNHpVatWvLNN98403/99df6vkpqm+O///5bRo4cKQMHDpQhQ4bIzp07Zf369VK2bFntDQl19UcpmeciJGdreEACJOAdgVMnc6RznMwZlyMRI0iABEiABEKGALY3nzBhgrz88sty5ZVXSuvWraV+/fq6/evWrRNs8LNlyxa9BTpmoCEMQisJQRTX8Int0BcsWCBLliwRTOl7CtjFctq0afLjjz9q29NZs2bJTTfdJG3bttU7XV522WXO2yCYIs9x48bJ4sWLZe3atfLSSy/pspBo27Ztuk4rVqyQ0qVLyw8//OC8tyAHXmtAC5I57yGBUCMQXq++hFWuIo5DB51Nj7y0g/OYByRAAiRAAiQA4Q42oCVLltRT4HfccYcTCuxBq1Wrps/nzJmjP/v166c/Dx8+LHPnzhW4w8QCIgiuCNdee63LtDvioPE8qRQgWEiO0KZNGy2M6hMP/2GdDxYjderUSV/FzpeYav/pp5/0effu3Z1lYDofefsTKID6Q4/3koAbgTBlIxP33AuSPne2ZKsHRWTLVhJ1VXe3VDwlARIgARKwMoFypUR6tHGtocms0vVCAc6wu2RuNpQQLs2hW7duepW8EVeuXDltFwotKBYfYfoefxBozQFaSsRjit8IsP1s1KiRceryee655wrsRY08cfH06dPO6f3y5cs706Msc77OCz4cuNbWhxuZlARIwDOB8PIVJPa+gVJi8DCJ7q5+lbo9FDzfxVgSIAESIAGrEDgnXqT/la5/d59RJBZqFW+99VZtF4ptz9u1ayejRo0STIFjkTi0lfPnz9f1gVYUwqM5wFazffv2Mm/ePB29aNEibTOKBUq4F4uRzAECaMOGDZ3pYQqAP5QdjEANaDCoMk8SIAESIAESIAES8JPALbfcIp999pnUrl1br4jHgqPbbrtNT4VjMRIE1GeffVYwXV6iRIkcpQ0ePFinefXVV7XQ+c477+g0cMGExUXuQugrr7wiffr00YuOEhMTBTajEEyDEcKUCvWsbjYYJRQgT0jrqFbPnj0LcHfetwAofiXAtYFdA1bDQW3uz+o0q7NB++BPrUqVKk6bFKvXuSD1S0hIEPO0R0HysPI9GKtY7YkpJfwit2vAcwd+9tynyOzUXtimoQ/t/tyB9gi2d3YNWGmNqV2sgi7q0L9/f5kyZUpRV8MS5SclJelV8Z6ek968J44dO6ZXupsbgw2G4NrJ03MJz+VgjwFqQM29wWMSIAESIAESIAESsBiBvH7YeaOk8LRhkCdh1mh2sIVPlFNoNqDQAGAl1YEDB4z28ZMESIAESIAESIAESCAECRSKAPrVV1/Jo48+qp2YDh8+XN5+++0QRM0mkwAJkAAJkAAJkAAJgEDQBVDYW06fPl07W7333ntlzJgxWhMKjSgDCZAACZAACZAACZBA6BEIug0ofFBhP3k4W0WA0Sv2FHV3FwDNqBGwMAErvbDIJNABxtVY4BSMvANd14LmBx9eYGjnNqJ9CGijec/bgjKz6n0Yr3buR4xVBCwqw57Edg3oRywisPNYRV+iD+08Xo3nDvbDtmtA29CXVuhHg7ddWYd6u4IugAKwIXxiUMMFwFVXXZVjFfqff/7p7Ivq1atrH1fBeCGhDhBAg5G3swEWODBeBhaoSlCqgPYhoB/t/FK3+1hF+xAgoNn5ZYPxamehBX2IvoRiwc7PVmO8uitQ0H67BCu9Iw3edmHLdrgSKBQBFEXioYQ9TzGgXnzxRddaqDPDmSouGG6YzjnnnBzp/I2gGyZ/CVrjfsMNE8aInQVQb9xrWKNHClYLCJ1w9wEXRXmtyCxY7ta5i26YrNMX/tQEzx08b+iGyR+K3t8bpXaWY7AvgaDbgAIdvrSDBg3Sm9fDySn8TjGQAAmQAAmQAAmQAAmEJoFC0YAOGzZMT6k//PDDoUmZrSYBEiABEiABEiABEnASCLoAunHjRoF9J/5mz57tLHjcuHHSrFkz5zkPSIAESIAESIAESIAEQoNA0AXQRo0aydKlS0ODJltJAiRAAiRAAiRAAiSQL4FCsQHNtxZMQAIkQAIkQAIkQAIkEDIEKICGTFezoSRAAiRAAiRAAiRgDQIUQK3RD6wFCZAACZAACZAACYQMAQqgIdPVbCgJkAAJkAAJkAAJWIMABVBr9ANrQQIkQAIkQAIkQAIhQ4ACaMh0NRtKAiRAAiRAAiRAAtYgQAHUGv3AWpAACZAACZAACZBAyBCgABoyXc2GkgAJkAAJkAAJkIA1CFAAtUY/sBYkQAIkQAIkQAIkEDIEKICGTFezoSRAAiRAAiRAAiRgDQIUQK3RD6wFCZAACZAACZAACYQMAQqgIdPVbCgJkAAJkAAJkAAJWIMABVBr9ANrQQIkQAIkQAIkQAIhQ4ACaMh0NRtKAiRAAiRAAiRAAtYgQAHUGv3AWpAACZAACZAACZBAyBCgABoyXc2GkgAJkAAJkAAJkIA1CFAAtUY/sBYkQAIkQAIkQAIkEDIEIkOmpWwoCZAACZCAZQmk//i9ZHz3jUhYuET37CVRnS+3bF2tWLH0Bd9JxoL5IhGKX6/rJapjZytWk3UiAScBCqBOFDwgARIgARIoCgKZq/6W9P9Ncxad9tGHElbpHIls3MQZx4PcCWT+tVzSZ81wJkj7cJKEn1NZIho2csbxgASsRoBT8FbrEdaHBBQBR3a2ZCz8SSI+nSkZvy4lExKwNYHMNatytC9rzeoccYzwTCBzdU5WmeTnGRZjLUOAGlDLdAUrQgJnCaRNniCZv/0qESoq7c8/JHvvHonpffvZBDwiARsRCK9cJUdrPMXlSMQITSC8CvlxKBQ/AtSAFr8+Y41tTsCRlKSFT3MzM5R9nCMz0xzFYxKwDYGoK7tKhGm6PaL5hRLZ+TLbtC/YDYnqepVENLrAWUxEy1YS2bGT85wHJGBFAtSAWrFXWKfQJhAelrP9YSoOfwy2IJB9/LikK/OK7H//1YJD9E23SFhsrC3aVpBGhEVFSezTzykeu/UipIiaNQuSTcjeExYdLbHPvnCGX3i4RNQgv5AdDMWo4RRAi1FnsaqhQSCsVGmJvPwKyVy00Nng6Gt6SFgEJuQZijsBh8MhqWNHS/aunbopMK9wnEyS2IEPF/em+VX/MPUDK6JWbb/yCOWbyS+Ue794tp0CaPHsN9ba5gRi7rpbIhqcL6c3bZSSzVtIZKvWNm9x6DTPcfiQU/g0Wp257E9x3P+g8kBEqyiDCT9JgATsTYACqL37l60rpgSgzYhqf4lkKTcqkeXLF9NWsNqeCEDDLdBmZ2U5L4eVLUvh00mDByRAAqFAgD+3Q6GX2UYSIAHLEAgrWVKi4dHAsOlV9o/QeDOQAAmQQCgRoAY0lHqbbSUBErAEgWi1ahlO1rP27pWI+vUlvEJFS9SLlSABEiCBwiJAAbSwSLMcEiABEjARCK9WXfDHQAIkQAKhSIBT8KHY62yzLQlkH1KLW5R7n+IU4Ns0/NBBcaSmFqdqs64kQAIkQAJ+EqAG1E+AvJ0EipqAIy1VUt8eI1kb1uuqRF3VXWJu61PU1cq3/CzlhihN1btkYoJkxcVJ5n0DJVI50GYgARIgARKwPwFqQO3fx2yhzQmkz/vKKXyiqRkLvpPMf9ZYvtXYblSU8KlDSoqkTvxAIEwzkAAJkAAJ2J+AJTWg2dnZkpycLAkJ/72cAtgPGRkZAkfQwcg7gNX0Kyvww1+mjbduzPrPhQ36ES6L7BowXvMbq5Hbt4v7L8lTWzZLdvUa1sWivoNRagGOS88pITRxxw4RD/uCW7ch3tUM/ZiYmGjrsYrvZKoypQiF506KGqt2DVZ6R6IuDPYlYEkBNFw5Yy5VqpSUD4L/Q7wE8KAMRt5WGSZ4AZw+fVrKlCljlSoFvB5o34kTJ3Q/2lkAhfCZ31hNb3GhpP83/a5BK4G8tJrKjgjC9yeQHZmi9q42zAaQb1j5ClKuwXkSFmnJx5JfTcdzJz4+XvBss2s4fPiwxKrtRO3+3MHzJk6ZjNg1HFd25BD88nvuFEb7o5SLMgb7ErDv09C+fcaWkYALgagu3SSqazcRPKzVD7eY/gMkom49lzRWPIm5934JV0KoAxrs6tUl9vEnbSl8WpE960QCeRFIz07Pcfmf4xskPTunRnLIujck25GdIz0jSCA/AvZTNeTXYl4nAZsRwPaNMX3ukujb7yxWU7zhSuMZPehZOaI0Z+WUtjZCac8YSIAEAk9g7+kDUr1EVZeMITT+b/dcuav2LS7x3x/5WdYmbZBXK7/gjM9yZMljqwfLTdWvlYfq93fGf7VvgUzaMV0alq4vfWrd6IznAQl4Q4AaUG8oMQ0JFAMCxdYUwcY2vMVg2LCKFieQkpVzYR4EwmXH/s5R87l75smiQ7+6xENrecsfA2RFwiqX+Fn/fiHP/fOqbEza4oxPy0qXN3e+Jx/vnyO7k/c64yGoIt3YLRPkSOpRHY96vbxhtD5+feM7cjLjlDM9D0jAGwIUQL2hxDQkQAIhSSBT2damfTZHMlcst237tTusLz6TjKW/iEMtXmQILoHM7Ew5knYsRyHf7P9Bjqa5LryFQHjj7/1zCHcf75otD/79jJiF0+TM0/LqxrEydP0bgjKMMHnH/2RH8m4ZvHakXoCLeAiLEBrVclUZsm6kkVTGb58q+1IPSIYjQ4b/J1yeyEiSNza9q9OcykyW1zf9nz5+f9tHsi/loD4+mp4gY7aMd+bDAxLwhgAFUG8oMQ0JkEDIEUj/YYGkvjFCMr7+UlLHvSNp06bajkHmyr8k5aUhkvHl55I2eaLyJ/uW7doYyAblZusI+0j3AOFxqLKPdA9Td32aIx7C4wtrR8jI/4Q74x4IhH8n/iNvbfnAiJLE9BPyphIIIfxBCDTC/22dLAdTD8u2Uztlys6ZOhqCriEYrjmxXj7Z86WORxyERoRfjy6X7w78pO99Z+skHYf/EPfr0WUyatP7kpB+doMLaE4XHloq47Z96EyLAy3ontrtEscTEsiLAAXQvOjwGgkUAoHMjRsk9eOPJP3rr7gjUCHw9raI9M/nuiTNWPhjsdtpyqUBHk7SleZTqcWcV7LWrJasbVud56FwAOHPPWSoaevFh12nspFm1r4v5OsD37skx/13LntIFhxY5BI/fvvHMlHZRy458oczHsLj6M3vyRf7vnOZEn9bTW0fTjsqM3Z/JutPbNLpD6UeEUMgnLxjhuz4T7gbtXmcHFdaSQQIgfuVIPrv6X1ae6kj1X+jN38gx9ISlZbz/wRaSyOM2Pi2rDuxUQuLRhw+X1o/Wl5e/5acznJ1L/XMmlfko12zzEnFof49uuoFF+0rEmQ4MlU+o1zS8oQE8iLARUh50QmBa5hizFq3VsLPrSaR7S8RLGhhKDwCGcv+lLT3z0xvodTMlSskbshLXA1eeF3gsST4ClYOLXNey/IQlzNVsYlxZOZc1eyx3cWmRaJXZEPQqxBTzqXW3+7/UdpWaCmVYio441Oz0uS63/rK7IsnS7noeGf8h0qDOG7bFPnj8m+ldFQpHY+p6DHbx0tMeIz0qNlNSkSeccUEIfFQ2hEZpoSvyyt3kOjwKDkjPE7U92GKe1HnzyUiLEJrLg3hEVPiCzp+ooTHvTJhxzSdFsLdYJX+i0umyqsbxjoFwkwl3A1b/6YMvuBJwfS7Ec7YYb6lp9zTTCvXkzJPyjP/vKy1mEZafEIjOmDFk1pYNMejDhBU65WsrXxIZ+nfJBEREbr8G6pdI+eXdvWqcTozRXpVv1oqRLsyNufJYxLIjwAF0PwI2fh6xqKFkvbxFGcLs9b+I7EDH3Ke8yD4BDK++8alkGy1PWWW0ohGNm3mEs+TwiWABV1RV3aVjPnfOguOuLClhFeo6Dy3w0G0cuFlNi0Ir1VbwpUvVquF3cl7pFZJ140VYOcI4e+p8we6VHfmv5/Ln8dWyriWrzvjjSnuKyp3lDEthjvjP9j+kaxVGkFoFUc0fVHHww7zLaVBPJl5Si+6Gdr4KR2PqejEjBP6GJrHZxo+rDWPE5SmE2H36T0yYfs0eaTBPS7C4+aT22Xqzk+lfcU2LsIjpsQ/3fOVLDi4yMW90R/H/pL/2zJJ5uz9Wudr/PfjoV/0NDkWIJnDl/vmm0+dx5hC71K5k5SNLuOMy1Y/rJIyTsro5i9JlBKUzQECddP4RmL4Aa1UqZL5Mo9JIOAEKIAGHGnxyTBd2X2ZQ+afv0v29TdKeJUq5mgeB5NAuPKB6R64KtydSJGcR996m/4u4AdBeI1aEtXtqiKpRzALjbqii4SViZfMv1ZIWKWKEt29h4QpzVegQtbePZK9ZYuE16olEfXqu2S7KWmbNCzjGgehKS4iVi4751JnWkyH3/bnA/JGs6HSodJFzvipK96VUYc+lIuljrQ//0zfQLgaqaadYd94d53bpFW5Mz/kDC3lLCWc3l2ntxa0DqQckne3nrFjhFbxrlq36vroFd1K+ESAi6E7a90s0ECap6Jhe3l7zRtluJq6NmseMZV+QZnzcgiPEHAb7m+gF/04G6AOoNWEZtU9oL4NStWVcNOzAIInNPOvNTnrHgn3wS61bsma0vGci92z0VrX8DDOauUAwwhLEKAAaoluKJpKODxNJ3qKK5rqhUSp0df01AtcDDu8cPWSjrigcUi03eqN1FrQzpdLlPqzc4hs01bw50uAIOTu9mvb6Z1yXvTZqdqMX5eqhU0T5OlWu+W1adWl1E23SfS1PXUxX+//XguKv1z2pVMTh0U7sEWMCY+WxZ3bSWT4mdeTtn9Uq7gxlb2w81wtVB36fJqMyp4qEi0yeNkQmZ9YRmLatdeaS2NxzZC1r8u3HWbKnpT9SjN5Rkupp7hV/FeXTtMrxg2bRwh3WD0+9IKnBBpUI8CuEUIiVoWbNY+p2WnymLKD/O3YCiOp/kzOOq3tI10i1Qmm3TFNf925V7tcwrR3+wptpGX5M4Ky+WKjMg0kPqqMOYrHJGArAhRAbdWdvjUmult3Sf/srD1RRJOmEl6tum+ZMLVfBCJbt5G4F4dqNz9hyhl71OVX0g7XL6K8uSAEPAmUyOfvxLXSslxTlyxXJqzRgtejDQY443H/SztGS5dKneTpsg9rTV3azOkyr1qCfFErUc5LipV7lTurqMuukLTYSLXgZbTsTTkgsLV8oF5fnQ/sIGGLiPDRrk/k3rp3aLdExiruTSe3yvRdc+Su8lfLqN1T5ES9M1PRG8qmyIxfRkunJmN0fjoD9d/fx9fK3L3z1BT3Yhct5bKEv2Xs5gny2V5X8xcsFnro72f1IhsjD3z+cOhnKRVZUspFxatrZwLmLVYfX6+1o1Viz/kvFuu5HJLuSJf+tW+XmIgYZzwOoM2kQOmChCchToACaAgPgOievdS0WyWB7ScWIentHEOYR1E1PULZ3OGPgQQCScCTUIlpZyyGOSfW1ZYVC1YGnf+gVI49a/f3V8JqufWP++T3K751xiPPweteF9g13lqjlzMewtw/pzbK9pTd0rdBb6kUWVZS0k7JG00P6Ca91/CQXL+7nJRITZX3987RwicuwNbypuo9tHYR09dGGL35fblR7bpjng7HNfijbFSvgsyse8YZujN93R3yg3JjhKlyc4AbJMNu0xw/bttkPQ0fLmenp6HhhPb1vZZn/WIa91SPO1cuUguYTp8+rTW/dt4L3mgzP0kg2AQogAabsMXzj7q4veCPgQRIwDsC2ceO6ZmD7KNH9dS1tqMsQu8RcNvTOL6hS+XhD/Jd5Rfytaau9oKvbBijprwj5Z0LX3Omh6A5ffccwYrwd1uO0PFnBM2RgillrMY24rEwZtXxdTqNEY8FPnCAjoD0r6lj5D/pimg5WOLMKvtTUdny1iWp8kKJTHlXCX9GwEIfCJmY4jamw3ENdpHPrnlZvjnwo5FUf0KYHLhL7T3uZjqdEJMpu9RCpW5VLnNJj7p1rtReWpdv4RKPE05x50DCCBIoVAIUQAsVNwsjARIozgQc6emSMvJVcaj96xHSNyufjUqrF92jV8CahUU3+5WmslZJV3MY+JXsVOliJTid1ZbD3c91v/XTbnuamIRQCJqf7/1WblFayuZlz9gUQ9D8fN+ZVf39aveWC9XUOgTNF5VNJAKESyzcwZQ7Vmev/k/QNOLhigdCpxGM+O/VFDcEXiPg3u5VrpSJZdaqFTJGrMjccjvl2JphOfxHzvhX+SL1ECB8dq96hZRVU99GQH1hf/lwtdsk4qfFknXwgESq2YNI2OpGxUqNEucaSflJAiRgcQIUQC3eQQWpHh7SkuXqqqMg+fAeEiABVwJZSuA0hE/jSsbSJfkKoIeVQBkff1aQwr2Y8sWK7RcveMLISn9O2TlLOUH/TT65+OyUNPbfHrXpPflJueKZ2/6s6zRoG6FFHKyEyC8vPbPQBjaahn0jfErOu3S6FjRxbAQcf3Pp/7SgCXdARsD0+ux2kwQOy80B8ZdUaKudpZvjn14zXO28s8McpY8fXz1EC4rmC1gAtEHtJ/5Q/f7maO3DsqFacHN1lZyLvWLVivhYN1tK58135NRqOq/xgARIwPIEKIBavot8q2DGH79J2vSPJUzZKqW2u1hi7h4gYTGuxvC+5cjUJEACBoGwUqWNQzkZmSWlMyMkrNQZR+W4AOEPoVX55vrTceqUnJ48XgaW/1QGbz9fOt4wSCKbnxGc4Bvy3W0fyiUV20rncy7R6eGDEvaPECp/OPizdK3SWcePUNPUmN42tk3sXvVKvUBo9p4zviL/TFgpWFneo2pXbaOpb1L/rUhYpXfdwQpzQ6OJaysT1+jV3u5bP2Lbx4Fqj3HsymMOiF+npvphP2oOG5VACS0ltLLJyckSGRkpMep5A9dAt9e6QcwLdIz73PMw4vlJAiQQWgQogNqov7P375e0iePVtFe2wEQq84/fJax8BYm5pbeNWsmmkEBwCMCxueH6x1wCfFNC4EOIqFNHIi/tKP+s/V5GNNsn/1vWWGKUv1CEM3aTZ6azv+swSy9WSZs1Q2Yl/iQb6qbIK/U2yVdqT/lSo8bKiRJh2vk57sNCGeyUg7IhEEL4RID7n8uUYAqtobGHN+LhqujySh1cBE3EY2X5yYxTThtNxCEMXzdastQ/9zBs3ZtKS5kqkWFnXwNoA4TWp84bqHf0Md9TWa327l3zOnOUy/FhZZYQGxsrZcrQdZALGJ6QAAl4JHD2yePxMiOLE4GsbVu08Gmuc9amjeZTHpNAyBOANnCX2rXGfXvBN9Ue3Viwgh1rjLBFrfa+96+n5OO278qVahcdhNh775fXfvhRlqUmy8JB3aXX+WcWAJkX6OAY9pfHt66VMW3OrATfWDZVZlc7IP3UblejIr5z7ue9RU1hT931qVxcoZXeC9woe2fyv8oR+v9kvtopB9PXRoCrokdWPa80oP8YUfoTbo0gtLqHg2mH5VKlZb2nzu3ul9Sincv1YpwcFxhBAiRAAkEmQAE0yIALM/vwmrVyFIcdSBh8I5CdcEwcajoRPlHDinB1s2+1Du3UsJGs5OZaCBpNLMYZ3uQZFzjvr31fFh77TeZdPtvpTH138l4Zv32qsrFcIj91mqN8Np5xzzNUaQlhqwltIRYAYftCTHUvS1WLj1R45d8J0q3+GTdCr204azeJ42uqdpF3mx6VhJiz2scxjQ9K8zIn5OP1Z/3vIp9RSvjFzjdmQRPxb2wap3xYpuHQJcC3Jfxklowo6RKP7RQfqX+POJKSxHHi+JkxHOE6be5yA09IgARIoIgIUAAtIvDBKDaidh2J7n27pM/5VC9CCleamZgbbwlGUbbNM02xy/jmjF1deJ26EvfUMxJW+qzdn20bbsGGeZoSx/aNWcrXo9ntEKaN+y5/RIY2HiTtlBbRCNAqwrk5bCwNW8p/Z30g78ZMkdOR2fLJu/2l9z3jJKxkSRm+YbTej3tD0mathbyz9s3aBvPnI7/p7LYn79JOzrF6HFPdRoDWEfuJpygXRtjpxgg4fmn9KJlVVs1AnFVeKmE0Ux7Y/qoWao20+ITboWS1K467lhLC72WVLlVbULYzJ9fHMRHROWwycSH9+wWS/smMM6Y4VavqMRxe6ayz9BwZMYIESIAEioAABdAigB7MIqOvvkbCLukgKQkJUqp27WAWZbu8s7ZsdgqfaFz2zh2SpnZvie3numrXdg0v4gZhC8c25cq51GLP6f3an+T4VqNc4rEdI5yNf3HJVGc8prux6w1Wgv/QabbWXiamn1CLed7TaSAIwpYybONmef3oTDldK1vHv3HOarn6y09kXbcmAjtPI8AOEzafuM8c4DT9aNoxpxN149o7WyYpgfJMnkYcPrGl42WVLhFoJTPUYqSouDi1HU6Eqn+WfKpWmiPeHLA4x+wI3nzN2+Ns5ZYofdb/YJCqb3EcOCBpM6ZL3ONPeZsF05EACZBAoRCgAFoomAu3kLASJQq3QJuUlr1vX46WZO/PGZcjESNyEIAD8JKRruPwi33fyYVlm0jtkjWd6Y+pVd/3bFL7b5f+QFrHnnWrM1wJf/AD2afmjU7t34IDi2Tp0T/1vfP2/yA9zu2qtIZnHKUjcl3SJpmlhL4+tW6SN9WOOdh/G2GH2kcc+4m32pMuX9RM1HH4D07Sxx39QRauO+Mb07hwLD1R7lnxuL7PiMMnFgfNVTv+tC53tp6Ih99O7JJzfbXuOHUJ1eKq6l2HEhMTtRum8CCbdGQrgdMQPo2KeBrXxjV+kgAJkEBREaAAWlTkWa7lCEQ0aqSWOSt7OZMP1cgmrvtgW67SRVwhODd332UGdpTzDyyUt1oMd9YOguJL60ZJi3JN9IIe48KbW96TpKyT8tKm0fLNOUpzp8LvR1c4d8CBxnNh58+0hnGYSSOJafAulTvJO1snurgMel351WxYuoF8vMvVxhKujepGKyflcA9hCuMrbpRSKaWlQrSrBnbzyW3yetMXpbxbPGxDr1W2nWFqX28rhvB69dQqKaVZTU1xVi+CY9jJggckQALWIUAB1Dp9EdI1wQ4zWRs3iEQru7aGjYrkBR9eparEPviIpKkpTPhvjFLudqK6XxtS/QJtXraavoV9oTmM2/qh1iyWiz7jTD076YSsmPu23FruM/kp+R6pd+N9EqammHE/FuxA69ivTm+93zbyGfPTi3Io/Yhg15yfV82RzhfeLNhCcuaez3Uxfx1fLV/umy89z+0mEDqNsEkJgtOUMHlKCbC71cp1I+xJ2a+3cPxo1ywjSn8eTU+Q+1Y+pTbgcZ0Shw9NiY6SJ8J7StY6tUNPRoaE16otEU2ayMWV2qhV4he55FNcT8LLxEvsY09I2rSPxKG2DI1s09bpJqq4ton1JgESsCcBCqD27Ndi1Sqs2D392sviUPZrCBFNm0nsk08XyQr0yNZtBH+hEFYqNz6tyjVzaepHaheelKxUeey8+5zxu5Q7oDfUlPb+1IMyQmkFEVLefkteqrFAUiOy5dWk2fLBhyJxDz8m2MUHC3YQhqwdqXfn2f7rVzIpRdlY/rcYe4hyFbTo3Etl8LaRLqu+X9nwlmD6e71aCGQO2C0IdpPuAWVhgZF5pxy9C5jK9fP2U3PYWIZLuFSIUZrOK9xzstd55AWNJXLk2YVS9modW0MCJGAXAhRA7dKTxbgd6fO+dAqfaEbW2n+0E/2oSy4txq0q/KrDv6W75hK1eHvLBHmkwQCXFdNf7VugNY1/XPGd01bzWFri/7d3HnBOVsvfn5RNsoWldxRpIopIkaKgYi+I2FFUvNiwl3v9e72KItIElCIocC1YULwWRFSwvBQREFCaUqT3sgssZXfZbOo7c7JPNtlGFlKeJL/hs+R5Ts5zyvc8eTI558wMG+5MVEY+vdnhuBbFRpa+nWz4I5F7+jbuTWc6qtIMxx+0sibPKrL80OgoLV4wj9rk36mi+KhE/k+i80g909lVkSOj2BR8U2YBPfv7C/Sb5w8tq3rdU7CfxmyYRLWsNYPSxRL86toX002NSu+xbFmlOZ2e1jAoP05AAARAAAT0TwAKqP7HKOFb6GEDjZLiPZxTMgnnRQREIduZv4eaZBQb88hbMkspxjBX17vUz2rZoRUcXWc8ZaZk0n1NfBF7ZIZTZhsl3KIop1oscrH+PubKVdcOWTeGJrQfTgsO/KaWzSVRlrVlefyDNiNp5Lm+2WqtosHt9tH5m3whJLU0eX3xr2F0MKP0WM70rKIHmtxFFoOFjnPYWImgYzabKNWUSv888+GYbMEIbDeOQQAEQAAEIksACmhk+aL0EAikdOpC7t+XFedkQyBz+w7F50l89E3WD9SvRnAEGzGwmckzizO6fegnsy1PouZ8zFFz5rDLoW4qjKLE4x5QtJ9yFDs0v5mttKvxHs63N0/xuxISP5l3s9W4GAl9suMrf3lf7v6W+p7RO2g/prwpVuhPrx9KWalOf145+LtKPuWxz8zWmb6oQNqbTnYG/3CD3tTtixXkPXxEJZtatiRL337UMI19VBpsdODAAarObphECYWAAAiAAAgkBwEooMkxzrrupblTZ7Iev5+cc3ifoNVKlptuIWODxFxWFSMdUcpK+oAcxFbdEtmmQWo9/1j9nPUL/WfTMDqv3rnUvrrPGl/8W2ouhiQijxjtiEgIRlkml/CN73L4xkeb91Pxw/88yoZdLIedR1W0ncea30cTNvOGzSJxcHsktrg4Qi9puPPY8udIjH1KysKDS+mFVk+TMTePPEcOk7FGLTJkpLMleY1yY4V7W9rZ+GcNW2jbyMR7FDUrcpfLVbJ4nIMACIAACCQBASigSTDIkeyi1+Mh5+zvybXkNzJUq0aW2+8g02nBS8Oh1J/S/TKSv0SSv46u91uBa/0Sf5SyzP3vs57Qkmj9sY00ectHtM+eRZrjdc2aXDINWDOcvu/2iVLaRm2Y4PdvKa6IrqrbnZYeWk4/Zc33lzd64yTlSH3Y+nH+NDmQyEASclKW4ANFZk2bZzRRPjoD00VRHsjRhdpWK+2Kqg6HvbRwWMpQxWDlJfYO54eaHflAAARAAAQSnAAU0AQf4Eh3T5RPx+ef+arZuYMKOHpQOlvgGjIyIl21bsr/bOcM6n1aL/+snjRM3A39+8/BtOiy7/xGPgfZ6booh6Jc3nX6rdSIl6BFZF+lzD6KGyIJxdixRjvlOF1cGYmsYGv1r9gBeuuqrYL8W0oYSHGPNHPvDyqf9l8eh3Tst+xJFbVHS5NX2Tu6hct8sdUzgcnquFlGY6W0lnoDCSAAAiAAAiAQAQJQQCMANZmKlJnPIMnNJfe6tSTL6vEsMkuYagrek/jBts+UI/W21Vr7uyaxyf+1eiCZOYziraf1VOmyrC1L4vvt2TSeFcTnW/lmO4fzjKRE0xF5lWOP//f8N1QIyIUHi/e/DmDXRVM7v6UUVZWx6L8h68dQs4wzSsUQf3Pzu2ytXpuaBEQXkkuOuwvocw732CCteElfK69pemMVrlI7xysIgAAIgAAIRJtAVBXQPHbuvXr1auratWu0+4n6IkRAlt2JZz4DxVAirnfge3o73sOziBIuMVBkj+P03bNodEAknyO891KsxJtnNKXvLprqzy6zlzKzKAritfUvV7OdYgy0Pd/nNH3ilinUp/HNdMyZq2KDaxfK/s17Dtym9l9qafK6+uhaepAdqWuKqvaeKLP1bXV5n+g9WpL/9ZLaF9AVdS/2n+MABEAABEAABPROIGoKqN1up1deeYUkFjIUUL3fFqG3z9L7TrJv20beXF/cbfPF3cnU4szQC4hSzuU5q9XspYlnKjXZfXwf9fi1D8279GsOuciKNIsoky+tGUF/H9tE/2Ar8DbVzlbpoza8pfZe/nF4FSun39PNjXpQYGxybbbzfnZ1NIZdG2lS6HGQ7NWU5Xcv/wuUx1f8h7IKDwQmqWPZE/p+x3E8A2ulXJ5RrlKlikq3Gq10Ya3kcJJfCgoSQAAEQAAEEopAVBTQrVu30gsvvEBVq1ZVfwlFMMk7Y2p0GqWNeF0tu8tsaKyVz025W9VsY4ca56mR8bKV9bHpn9FDNJYePng23Xf1QDJxvGxPziEa+ONDlJV+gIZ92Z9GXf8OGTIzaeqOL5VRkFwss5vfdPuINuRuYSfsRftcOX3w6tfosjoX0SvrRqk6tP9ktlOiAMkezED5bt/PdHZmS7qgZrARjkTtebvDiFLpcq3EHBfJMedQjRo11HEs/hN+ji8/J9fvS8lQoyZZ+9xDpiZNYtEU1AkCMSXg/GUeeWZ9xx9OIzl73UwpXS4gCSEse+BdK5aTsU4dstzFnw82wvRkZVHh1A/Js3s3h3s9l6x33kWGtLSYtv9kK1eGpjNnkHPhr2SoksGhXfuocMknWx6uAwGNQFQUUHE0/eKLL9Ihjk08a9Ysre6gV7e7ONSefDFrf0GZwnjiC9kXxgJ1VJTGLmp95AerqSh8ZSTqFH+WmkKmYc5z5tOkPR/RwLr/pyWp15d59lJcDs3q9qkyCnLwg3PSlg9ozzl2Gl17NfUYN5TqDRlLC94bQN+33Kau+TR9Ld01ZSg1eeQF5cxdK3BpzgqasXs2ffLne+RmIyFN9rkP0wMLH/Evs2vpMtu5gWdOxZF6SWnBS/c3Nry2ZHK55xpHbSzLzRjhNxzTv1ReDqQa78GDVPD6a5QWRiMzvfQzwhj9zzOtv5GuL1blx/p+jVS/XX+upsL33/UXXzhxAslWI9fSJeSa87NKdx86SPbXR5Bt6Aiyjx7lj+7mWjCfvIV2sj3yuP/6eDjQ7lXnj7PJ8fVXqsneA9lU8MYoSh0+kow1gyOWxUOf0EZ9EYiKAtq6tc9oY/78+WX2Xm70s8/2LXVKhrZt21KPHj1o//79ZeYPR2Ikyw5H+8JRhij+8SSiwFmNllJNfn7LUBpwxtOUYUr3vzdh9/v0/r7P6NLqXallWjOV/uuRpTSPnaGLvLP2Y7qh1lWUu3IeTWqXrdIOW930ZuOt9Mzcn+jVun+oNPnPYyAalD6fmv5hohyHz1m69ubzfw6hI66j2qn/dWnuGhrS9HmqmcKxxUtIp8y2pRRmyXKy99zJXleiWSd1mrZsiRbC3Xc97+M+uGwpudmXZzjlyJFg7uEsWy9lZWf77kO9tCcS7ZBnTrw9d0LhYP11AZV8Mh3jNPPqVeRbq/CV4uX7OIcV0tT9wZHCXH/8ftKf/1DaF4k82nMnlQ1NgxQFRyEdXryQnB0jb2jq4BlmSOISCLqvYtVNcUo9cOBAf/X79u2j1NRUyuQl0XCLPBxF4U1PL1Zmwl1HrMvzsG9O+eDqObKMKHravkuN18jNE6h1lVZ0Xd3LtST6IXse/ZgznxplNKAXWjyl0ncV7KGP9n+p9lSO3jOZpnUQ10YuGr2meO/lhD3v002nX0ejW+6kAnPx7OXHzQ5StepraJ2xwF+HHCypk0+78pZR8/Tg5WW5V5492pFu+LnEj6F77yPrGZ3JbIzsR0ju17QYLt15a9chDlUUxCqNt13IdoVwiNyrYpwon/eUlND9ioaj7miWIeMofdQc8Eez7mjVJfuVZQz1/Nw5WRbe+sGGilKOpUEDor17iI4F/EDl77JU2QPP0dwoYFXPULNWRL7PTrY/FV1XUFDATXdTRpErPW+dukTbfatF2nU2fgakhukZoJVZ1qtJOEISlkBkvz0rga1Pn+Jwg99++23ElERRzOTDlcgKqESX0YOS7eUvpO3bV9AZTc8nQ4DCP3vfHBWl58NO4/13yHaO4DNl12dUx1qLeja+mmxsgFPodtCILb48H+36nO5vfhc1ZX+VI9e9zVF/fKEglx1ZSXOPLiKxZt9esMtf3gHHIRqydQzNyAx+cLp5uuIr52K62dqZPJs38fSnV+3pMrU8i85o1Ib+76zH/GVoB968XCpYM5T3c/nKN3XsRLaLr4yKMlFYWBjTe9Vzz71UMHI4h9E8rHCk9LyBrBxKM1wi96oooKK0JKLionGS5478kBAjzESV/Px8pYAm4rPVe/0NVLB2DXm2bFbDZzq7NdmuuoY857RWy+7eYz4jTMvNt5GFVwecd/elwo8/5OcL//jlcU+9/0EyBTwD9XwPOJ3OoO8Pzx19qIAVUG92lmq2mQOG2KIUKhkKqJ7vlFNvm24U0FPvCkqIJQGx3D6rSgu/UiZLTls+Gks3dVtLs95pQ40efJbM57ZRSuXAtaNo5/HdtODAb3QxuxASkTTxnynO1SVW+T9bPsx7Nz/kfDzDwCJhJsW3Zv9mfZXvTJVY9N9A3veZW8LwR94Sa/WnWjxI1Yzpav+iQWagqvqs3fucfjNldHSQZ88eMp7OfjHZQK48MWRUodRBQ8i9aSMZJJRkk6blZU24dAmJKns+3aysG9kYKlFDpCbcwKFDYSVg4BDBqQMG0vE1f5GBZ+VsrGTKbLap8RmUNvIN/nxsJmPt2mSs55spTbnsCjKdex55eClejPbkGRKvIns904ayuzl5/rFHDhM/LyEgEA4CUEDDQTGJyjhQeIhynXlqJlLrtouXv/v/8SzHH79PxQIXy2n7e+/Qa+dupxybi15vvp1GvDOZTGPH0+StHynlU64VK/O53afTooPLVOQgrTyJVS5+Lcdt+q+WpF4lNvqGXN8MROAbezmE5e22rnTdvOB9VylXXk0tGt9Ip6c1JCpr0o6Ny41s2R2KGMxmMrcq3qccyjWJkkeUbjNb8kJAIJkJGHj22tDc9yM7cCuFITVN/bguyUYppKyUJoIYLBYy82wvBATCSSCqCmj37t1J/iBsUSzL5LxkVdHMW6w5zcteSJfW6RbUDInmk20/SFO7vO1Pn7L9M9qYt5WGsjP2ng2uotTcQlqWlkWzG/n2Rn3VOIfu3rKXmhzbQ2MDfGSKe6Mp7N5o6o4v/GXJgUTxEYVWrN9t7PtSE9lWkGZKpd+v+Ikc9kLlI7M2P+Dly8D7zbdUNXu+llW9mneaySbKJySIgHvbVir8aAp5eG+nuf35ZL3rbpJY7RAQAAEQAAEQiBaBqCqg0eqU3utxrVxBdp4RpPw8Mp7RhGxPPEXGWrH7pSx7MiWKT6BI7HGxAF98+fdU2+qbJfzzyDqatvNrZfwzN2shXVa3m7Iaf32DTxmV2VFRMP/T6ika3LHYcMXLVuaDuxym5tsmKeUysJ7h68dS/dR61LJKs8BkMvA/mR2VPZ9lCdvaUlqhjerxtaKAupq3JTvND8pqas7GAJAgAl42hil4YySx9q7SXezbkExGsrFRFQQEQAAEQAAEokUACmi0SBfVIwYt9okTiNi4RMTDm7sLP3ifUp/9N4ly4Fy4gIhnR80XdiOjhLkMoyw7tIJO4xnB+qls1Vgkssfy4eX/R2+2G0a9Gl6jUvPZx+bgVa9RriePhi8bSqMvGq3SZclci+bz8toRvH+zC438ewIddfo24EsmWWLPMKfT+rTiNElfnn6QCo9toMvZgXtJubVRT7qp0XUlkyt1bmY/pCk9e5FzFjuK5o3/sgfLfPEllSojGTK7t27xK59af92rVhLdq52d+qvsF5XZfdNZrXhmtXgG+9RLTo4SZK+dPAtMvOVDlj4hIAACIJCIBKCARnlUPXv3+pVPrWpRCuQL+/jLL7KxjG/m0PHdt5T26pCTmhmVSDy/HFpMvTKLHZ/LcvZ//hrKM43NVfQdrW4JE6nCRa57na6q153DP9po7GeP0P6qPr+M03J+ont+/R/taJpJ4phdk81520iW4z/a/rmWpF7FkOh/u76hPqffEpQuJ4045roYF0VKrLfeTpYbbuT9DV4oPuVANopbJZ4xFkaaGOvW0w5P+dX+9njlnFsKMnBdqS8MCHmf7SlXHucFyBYT+4Rx5GYDPhEDu79JffEl/iFa2tdsnHcVzQcBEACBYP+y4BF5AsaGjYhsqUT2Yj+UslQsYd405VO1gpfnnbNnkZXd4FQkM/bMLhVhZywb73y953u68rTulGbmulg+2fEVreUZSPm7v0kfklCViw/+ThImUmRPwX5lfX6r6XyanMEzYkUiy+cDto+n/fbSewTf3zaNHmh6t1JatfzyKsvnjzS/l6qmhMdXZGDZJzrGjFHFhIx165Kl953k+N80n6LOlu2Wuyu+xyousfhd2VoikWE0kagpjulfke2Bh7QkvFZAwL38D7/yKdnE7Y1jxnSy9u2nwqHKM8KQls6hEO8kmfGHgAAIgEA8E8AMaJRHT/xh2h57ggrfnUzeo0fJyFaV1n/0IxdH1SgpXqfDnyR7Li+s1VH5x9QSRYGU5fPTUhsohVLSt+XtpPe2f6LcFo3f/C79+6wnVGz01/5+U7uMXlwznL7v9gkN4CX1QBHr8xWpS8lhKp4dk/eX82zobTV7UuuqrQKzq+OutTpx+lml0iOZ4OGQd55PP6E0dnHi6NSZLD16klipQ0IjYLm2B5mZm5dD48oe5HAp7d6cnFIN8OYcKpUWSoLE2JbtKqF6KQilzBPl8XAUG4PVQmLVHAvxlMFKxsj584/k/P5b1SRvXh7JLHPa4GEkP2YlTrf3cI5yLxbKZ0CYisSzWyDVAfwHAiAQ9wTwrR2DITS3OY9dEvE+UI44oTlolz2fDt6/mEW5dMTiopZ56ZRyqc8wKN91nJ5Z9RL9o0lveqYozrgsqWsK5ABWKGddNE0Z44ivTPGZKSL+NGUp/N2tU+mQw+dIXNJXHVnD5b1M63g2NFAK3HY6bC6k13Z28DsdlvdFWWnY8EpldBSYPxbHXnaSXDBiGFFWlgoR6RTn8Lyf1nr7HbFoTtzWaaxZi0j+wigmvq9J9iyy8qiJ+STC9TkXL+J90e+pcVVGek/9U/kg1coM96uX7x/7W+PJvZpn/o1Gstx4M1l63RTuak5Ynvm8duT4/DN2euv05xV+riWL/efqgANpuNauIZPbQ/bxY/izmq0iU1k51riZ/VOWJaKoFk55jyQuuYj50svIyoZnge6E1Bv4DwRAAASiRAAKaJRAl6xGfMots2+gTunt1VviMy5t4GB6feGTtM+QR1+1H+l3eD5u0zuUVXiAxm96j+447SZlRDR1x5d+BXIlK5Rf7J5Jda216aes+f6qZG/nc38Ool8PLPWnaQc/Zc2jcW2HktXECkOAyPJ5j44XkXvWLKWEmtq2o5QLugbkiO2hR/bLsvIZKK7FC6GABgKJ0bHcw2JMV/jF/9iXVj4bgXUnc/dLK9UaD8/4Fb7H/l9dvh9Rykhv6keU+uTTlSqnMpkd387wKZ9yEStqjulfkkTGEiOqaIpsj7D96zm13C4/Ts2XXEopbEjn2bGd3KxwBoqxfgMq/O/bSvmUdInEIzOj6WPGkyGldEhT14Jf/Mqn5HfNm0smXn1J6XaxnEJAAARAIOoEoIBGELn4+pSls7UbfqFWNc4mCxvJaJbtP+ybS0+vGkC/XT6bqluqqlasSj1EX9v+VsezU7fS9dScduTv5ohAH6g08Y85eN1oeq3NAHpt9euy2dIvg1cMo6pV2MCkhMzLXkTP8zK8GB+VlHbVz6V6ttLXSD7zLbeVzK6L87JikBsyffx00cAkb4QobmkcMeZkxbNnt1/51MoQJTSS4tlWunw31xltBVT6KMEOzC+9EtRdy023qEhUGoeUK64kE890enbx7H+gsGstWbI31CttVCb9KSmq31BAS2LBOQiAQJQIQAENI2jxgymGNxajbwbC8b9PKWfuLLrr6r/prSXbqPPr2yj11aHkJLcKPXmE3ReN2jCBhp3L1u9sATvgr2H+1gxi6/Qr6l5Cg9g6XSzLNZnOxkVul4NyDMe1JPV6wJDPs6nN6KWz/6li3UsMcYk9LdKQrc+jvU9TVRyB/2TmJ+Xqa8n542xf6ezmx3LnXRGoCUXGgoCRQxuShV03OXxuyqQNpjPPjGhTRGl2r/krqA5Ti5ZB57E8MWRkUOrAV8mzc4fanyozpSLGZs39scnl3FC9Bhlqlb2twtSyJc96zpFsfpF+Q0AABEAgVgSggJ4k+WPOXMpMCY7vO3jdG9Qioxk90eJ+Vapz4UIa3ypLhaMc3HYvzZiTrr5E/uucSzuO+2YvPmQ3Rn0b96a/jq6jFUeKvwR3Feyl/7Aj+Fn7/l+pFv55bD29/VtjTg+YAuWzqo/1osvrXcqrly46zn4EMzOjb4VeqrERSLD2uZtcHFf+OH8h1+hyAZnCvJcxAk1GkSESkMhgtscep8L331VGeiYeZ+tdfUO8+uSypVx3PXl4W4dr0a9E/IPGevudZGrW7OQKi9BVsmXHxAZjgWLr/wj7FH6LPNu2kkGW7/s/Vq4xnmyjkRlT5w+z+LFhoJQiQ7TA8nAMAiAAAtEkAAX0BLQlzrnZGIxpwYHfVAjJKZ3G+a9eefgv+nzXTEo3pVHv03pRHVst2l7bSB819/n1XFetgL44I4eutzhozNrJ/uvcXje9wP45t+Rt96dpB9P3zKIRbV4q053RhTs2UdqvxXs7zWywZGtUuf12Wj16fnVv3KAMLowNGipjKM1owsCzPy6OHhVNK2k9c0qktpnbtifTuLeUMU64LPQr4iPW47YH+5P3HxwNymQiUfbiQcR/a9org0mMqEJx+C+Gepabb1VdC8ViPh4YoI0gAALxSyBYs4rffkSk5YVuB92z7DGa2vlt/7K6KKQSEUjimItxz0W12Z2NLJ8XuTTKdx/IjfvjAAAgj0lEQVSnYRxecmy7ITS8Wy657MVNG90+h1bsm0KSJ1AWH/pd+eY8pwx3Ru2qtaZWmaWXIL33XU3Oxi1JjHLEj6hYtSaaOOfPY8vdd/3dcv/1J3xK+mkk9oH6oRHlKEBlGe/EA+VQlE+tH3pQPMXdlBh6idsusfIXQzXth6XWzpN9de/aSc6ZM8hrt7MXkcvI3P78ky0K14EACESYABTQIsDjNv6Xbj2tp9ovqTGftOVDktnO/275iB4vWlaXJXNRPkVEEZ3T/UsSZ/DLD6/WLqPPds1Qey7n2IvT5M1DvG9znz2LXjnn//x5tQOJEnR9g6u00xO+yiyN5cqrT5gvnjM4pn8R1HzXr7+Qp9eNpKL5BL2DExAAgXggILO1BcOGkAQpEBHrfm+hnSzXXHfKzRfFtmDIq/4gH+4/V5PtmWfJzJ48ICAAAvojAAWUx0TioY/eOInWH9tEk84fpUYpy36AxnFEIZExGyerZXUzGxeJ0ZAmf+duUj42J7KiWlLe3foJPdHctxc08L0ULuOBJneVWtYPzKPXY3GC7Vwwn7813GRm61lj9eoRbar4/CwlTp97nlLpSAABEAg7AfEfGs4tCe6/1/uVT62x4iIqHAqo6/dlfuVTK9vJZUMB1WjgFQT0RSBpFNAt+4h28HbM/HwLu/rzUJW9RHXYe09rtuXR4qHP2Dub+h26kzrXbE9D1o0hcXskIkvmQ3lZXeKki+V6oIz6+23loN1itAQmq+PbeS9oiypNS6XHY4JEUDn+0gtq2Uza75j9PaUNGsqzkbUr1R2JNuOc9R152WWMudtFZD6ndbnXp1xxlVpO0zKYzm5NxgYNtFO8ggAIRIiAm11TFb4zicQtloldQ1kffJiMNWuecm2GIs8cQQWVlRaUIbSTssouKy200pALBEAg0gSSRgFduJ5ohrLZSfcz7cKeVo6lF8dDlzckqtBr5w5Qjt39GflAltXPq3YOdanRITBZHV9W5yK64/QbS6WHMyHcMxGVbZvsxwwKtZifr1whWe8O3ULZy861C14dyL4KD6rqxYG8jaPcmNuXZioZxGBCltvda/5UYQfFchcSOQIyW+T49hsVI95yXQ9KueyKyFWGknVLQPwX298c7f+8u9evU8po6vMvnnKbTS14v3qnLuRatsRXFu/zDVcUMzNb+jvnzlH74qVwQxV2iXdDZJ/LpwwEBYBAEhNIGgW07DEuNh7S3v/r6Hp6/q8hVMda2p+exFx/t+MYLWtUXmV/lAqht3SJL9xe335k7hCDjfVlLIfLF1VlxLVyhV/51K5z/vxTuQqoGCZIJBj5g0SWgGvdWl8EoqJqCj+cQoYaNbF8GVnsuizdm7Xfr3xqDVRL52xsGQ5jIeujHDL0wq6qDgnfWtlVFK1NJV/FwCr1xZfJ9cfvaine3KEjK6HBrvJKXoNzEACB2BFIagV0Z/4eWmcOjocuQ7HPnk2/XfY9VUnJKHNkvLwHklxOdn1iK/P9cCY6vvqSXL8tVkV6efnaPnECpQ0fFbaHdqhtNV90MTl+YOfvdt+2BHFXI1amlZEyLXBTkvoWrAw+lVc8LrhZWZT9uGb2kRmuJUb3qpWl2uJatQIKaCkqiZ+gnNnLsjj7EtbE2Oi0sCifUp4oseZ2vhDEWvnhepVnTAr7Bi4pXu6Li71oiFN/iSIVDkW6ZB2hnMtKlgp6wFb6onwbbJH/DgmlXcgDArEgkNTf/g3T6tHf1ywqk7vs9yxLnAsXUCHHppZYzSaeibQ99Ih6iHj27ycnW2mLKxdZuiwrZGRZ5Z0oTZa/goRnIt2bN0VdATWyz820QUNYCWVH1h43pVzO4QAlak0lxMRL7UZ2pq2FFCRmhSWy0AGK8mkfN5rcPJMs4qhWjWd8BpKxTp3QCyknpxZdJ/BtY526gac4ThIC8sNaObmfPFEpoYaatXgPaP+47b0nO5sKhg4i+QEvYmLlV7b+RFsJlYkL+6jXSHumi6KfOuCViBtzxu3AoeEJTyBpFNBqvPWzEe+h97DyJF/kJpOZ6lY1U7WiOOyhjLRn7x5epnxHClHZ3cv/UP7szBd3p4JBL7FG4FDpzvlzKW3IcP61ferLP8bTTlfRk/zt49kDY6NG/tNoHhg5xrRNnHWfpPiXyFhRVzN4nTqThNaEhEZAFE9N+ZQr5AtVXFXZHn4stAIqyGW+hCNoSfk8SyQihidiBAZJTgISDCB97ARfbHn+gVPm6kWcoJHPiKZ8SpO1z1F5e88j1S3XksV+5VPq8B48SI6ZM8h2b79IVYlyQUDXBJJGAe3VmUj+Dh8+pmKl1yonZnJFo+Vmp++a8qnlc2/awE6PC/zKp6R7Dx8m58Jfw+JaxNL7ThLFV8LtybK3haOZmFgpjVeRyDYyewqpPAHv0aOlLiorrVSmEBLUj4Nn/03u7duUEZLMVEd7hiiEZiJLFAmIg3tDAnidKOszUlZapNGWVWdZaZFuB8oHAb0QSBoFNBzAjbLkzDOQPIXqL87UpBl5i2Y+/YlyUDRLGpR2EicSGzt14Kvkzc5SM6qGdJ7KhSQlAZM41LalFu/DZQpi+VuRyGy/zP7IlhAD/4A5kZSMN36i/HgfBPROQD4jsm/aL/wZUp8lf0J0DsR4VCJAUYBBZ8qFF0anctQCAjokAAW0EoMiM4/We+6lwmmfqIeIiX1YWm65jTwHD7ChEO8lLbIKF/cf4uMyXCIzUQaO+wxJbgLi+F9c4aglRTZCSrmoYg8Bnr17qWD8WPLyDLoooFZeqq/I76re6Yoy7dm+nZvpVXuJMUOr9xELT/vEE4iH/ZIa2A/pyURBU140+Nms9uizEZLl5ttisu/SyM/w1Of+Q44Z032hQtlWwHx+p/BAqqAUCUsq++5lz6ns5YeAgF4IQAGt5EjI8rFEAZKHojGTPdmzmHhWMpUNdFzsK5NkiZn3zmnvVbJ4ZAeBCgmYmjSh1H89V2Ee7U37u5OV8inn3mPHyP7WeEof8yZ7b7BqWeLmVfmmHPO6z4KYWy17VG3MIV7jt8cN+Bg31L17F9lfH6G2Ncnqk+W23mTp0bPSrUq57HI2Dr280teF+wLTmS2VEhrucssrz71zB9nfGOnbAyv87ugTlq1h5dWHdBCoDAFjZTIjr4+AfIGXVDBN7KZEnLKLU2VjjRpABQIxJ+CRPcuBkp9HnqIY3IHJ8XDsnDfHr3xKe8WS2Dnn53hoOtp4CgQc7HFE9tQr4Rlwxxf/Iw/7KYWERqDwow+KDbCE32ef8jPgQGgXIxcIRJgAFNAIA0bxIBArAkaOOhMosjUkXl0ryR7okuLJKp1WMg/O45tAqTGWbRhsPQ4JjYCXXVAFieIHBTSICU5iRgAKaMzQR7diccJcwD4kxZG9e9fO6FaO2mJCwCbxu5s0VXWLL0fbE0+ReCGIRzGxW6CSEiln5iXrwXnsCJQcY9nLbGrqu6dj16r4qVl8ngaKoWo1MhU9EwLTcQwCsSCAPaCxoB7lOiXMouyj0kT8PaYNG4EN6RqQKL562CJdPCREY5uGOKhPe2UweQuOK+v5eDbaEeMp6/0Pcqz6mTxaXrJc15PMHEkGktgELL3vYKcjHD1o+XIy1K6tjEANqRylCRISAeudd6l87pXMjwNLiBEtoi+FhA6ZokAACmgUIMe6Ctcv84ObUFhIriVLyHJ95TfzBxeEs1AJiAV34ZR3SRsLc+cuZO3/aEiukUKto7x8ifKFncIBH+QPkjwEVFSme+8jkj9IpQmIsmnrdz+R/EFAQGcEjDprD5oTCQKp7DuyhBjSSqeVyILTMBJwLV7oVz6lWNfSJeScOyeMNaAoEAABEAABEIgfAlBA42esTrqlMtMpBiiaGE87TbmS0s7xGnkCnh07SlXiYRcpEBAAARAAARBIRgJYgi9n1CW6kfP7b0nCb5qat6CU666PW5+D4nw4bfhIci1bSmS1kLlTl7g1RilnuHSfbDr7bHL+ODuoneLLEgICIAACIAACyUhAlwqo7JdzsAJ4/DgbT4RZ3G4324B4Tli2551JRCuWq9rdf64mx86dZGQjiHgQ6aOTw70F8ZMwjBf4wr45JWJTUdSmeOhPWW2U+0NE+hgXxjVnnkWGXjeR94dZvjCtHNDAyaE1nSe4x2Usg8axLBhxnCafRZFC3pesHcdxd8ptuoxjQUFBfNyr5fai4jdk/Eo9dyq+JO7eleeOPG/kOypRxcXfDaF8R0aj/4n8TIgGP73XoUsFVIMWScWiorK9ohQUKZ9aW+iPZUTsaD4eLAilb9qfv/0JehBP/TRc24O811zHRtxeMhhD3/1S0b2aKMMaT+N4KswTeSy1MUzkPmpjn8h9TKZx1MYTr7EhoEsFVD4AFvZXmFqG8cypYrJzXFyRisr28mxhvpnRBM4SpqRQKscRjofQf9ov2Ir6eKocY329zEDIjJL0MZG/DLQ+xpp3pOqXezU3N1d93m1ssRvPIuFC3Wv+Ul0wtT6XDPIMKRJ57si9aqzEDw/t2nh5lXE0c58T/bkjz5tE7qO2GqGHPiby5yVePteRbGfxEzKStcRZ2eKs23LzreT4/DN/yy233BYXyqe/wTgAARCIGgFvoZ0Khg4mz47tqk5j4zMo9cWXSNwIQeKPgIynNy+fjDVrxl/j0WIQiBMCUEDLGShLj55k4lCG7i2bydSsOZnObFlOTiSDAAgkOwHnzz/5lU9hIYqopFmuvyHZ0cRd/53z51Hh1A+JN7SSkZ/9tiefIWO1anHXDzQYBPROIPSNaHrvSQTaJ0qnhfftQfmMAFwUCQIJRMArEa5KSFlpJbLgVGcEPFn7qfDD95XyKU3z8ASE47NPdNZKNAcEEoMAFNDEGEf0IoYEPMeOkrfImjuGzUDVMSRg7tS5VO1lpZXKhARdEfDs2unzUhHQKvf27QFnONQIeHIOUcEbIynv4QeoYMRw8mRna2/hFQRCIoAl+JAwIRMIlCbg2b+f7BPGkmfXLjJUrapCa0rMckjyEZBVEttTz5Dj++9U5y09rsfKSRzeBsYmzYjY4FSW3zUxtTxLO8RrAAH72xPIs2mjSnGvW0P2N8dQ2pDhATlwCAIVE4ACWjEfvAsC5RKwvztZKZ+SwXv0KNnfGk/pY8bB8KRcYon9hrn9+SR/kPglIEZHtocfo8IP3idv7jEytetA1tvviN8ORajlXvZAoimfWhUye+w5fJiM1atrSXgFgQoJQAFlPLJ86t23l6hKFTJmVq0QGN4EAY2Ah6NkBUl+Hnmyssh0euOgZJxEn4CXZ7Ak8pSEQDW1akXm7pdVyvdq9FuMGvVCwHx+RzJ14B8S7FYrHtzuxYQbu0wzsKLpZYXTL+npHPK5iv8UByBwIgJJr4B62HjAPnqUz4JV/I+yuyVLz14n4ob3QYCMHKLVs+HvYhLsJ9ZYt17xOY5iRsD+9nhyFwWTcC1bQrJdwtrn7pi1BxXHFwHlW1iW4iFlEhA+1gcf5i1Ib3I4unwiVkhtfB7o+7bMC5EIAgEEkl4BFV+fmu8+iVDj+PJzMrU5j0zsxw8CAhURsN3/EC+7v6nuH5kNsD70CC+/Wyu6BO9FgYAYR2jKp1adc87PZLmjD2ZBNSB4TWoCnkMHyTHtU3Lv2U1mDppguZX9XFfSZ63sd09/g/fA791DxvoNyMAzoBAQqAyBpFdAPfwBLCme3buhgJaEgvNSBIx161Laq0PZYXUeUVoalJtShGKTYDCXMXMlUYl41gYCAslOQLac2dl63bNnj0LhZAXSW3CcbA/0rzQaAz/3TLwSBAGBkyGQ9G6YTCWtlnnZBX4/T+ZWSt5rDBKiNYFDLMbbyBoyMynlqquDmm25mWd4oIAGMcFJchKQCRZN+dQIuJYu0Q7xCgJRI5D0M6CWG29ma8dccv22iAxsgGS9514y1q4dtQFARSAAAuEnYL2rL5nOOpvcO9kIid3omM8+J/yVoEQQiEMC8gON5AdzgO9iQ/UacdgTNDneCSS9Aipx3233P0gkfxAQAIGEIWBmS2b5g4AACBQTkLCiltt6k9g/iN0D8b51a99/FGfAEQhEiUDSK6BR4oxqQAAEQAAEQEAXBCzXcaCENm2V+0FjixYc6x6+O3UxMEnWCCigSTbg6C4IgAAIgAAImBo1IpI/CAjEiEDSGyHFiDuqBQEQAAEQAAEQAIGkJQAFNGmHHh0HARAAARAAARAAgdgQgAIaG+6oFQRAAARAAARAAASSlgD2gCbt0KPjIAACIFA5Ap4jh8k5exZ57XZKubg7mZo1q1wByA0CIAACRQSggOJWAAEQAAEQOCEBifhVMHAAeY8cUXldv8yj1P8MUH5WT3gxMoAACIBACQJYgi8BBKcgAAIgAAKlCUi0HE35VO+yD0nHzz+WzoiUsBIQxd8r/johIJBgBDADmmADiu6AAAiAQEQImEylijWUkVYqExJOioB79y6yvzWevByr3VC7DtkeeRxbHk6KJC7SKwHMgOp1ZNAuEAABENARAXOXC8hQt15xi1JSKIUdmkMiQ6Bw4ltK+ZTSvQeyyT5hHHkDwmdGplaUCgLRI4AZ0OixRk0gAAIgELcEDDYbpQ0aTM55c8lbUEApXbuRsV79uO2PnhvuLbSTh2dAA8Wbc4i8hw+ToWbNwGQcg0DcEoACGrdDh4aDAAiAQHQJGFLTSMI4QiJLwGC1kbFhQ/Ls2eOvyFCjBhk4jjsEBBKFAJbgE2Uk0Q8QAAEQAIGEIWB9+HH/lgdDzVpke+xJwp7bhBledIQJYAYUtwEIgAAIgAAI6IyA6fTTKW3E6+TNPUaGjCpkMGK+SGdDhOacIgEooKcIEJeDAAiAAAiAQCQIGAwGMmRWjUTRKBMEYk4AP6liPgRoAAiAAAiAAAiAAAgkFwEooMk13ugtCIAACIAACIAACMScABTQmA8BGgACIAACIAACIAACyUUACmhyjTd6CwIgAAIgAAIgAAIxJxA1BfTgwYP0448/0oYNG2LeaTQABEAABEAABEAABEAgdgSiooCuXLmS+vXrRxs3bqTnnnuOvv7669j1GDWDAAiAAAiAAAiAAAjElEBU3DCNHTuWhgwZQueddx7dfvvt9MADD1CPHj3IYrHEtPOoHARAAARAAARAAARAIPoEIq6Aulwu2r17N7Vp00b1rm7dupSWlkZ7OMRYkyZN/D2eMmWK//jAgQN0xhlnUF5enj8tXAfSHo/HE5Gyw9XGUy1H+ud0OhO6j9I/EblHxFdeoorcr5H4HOiFl9yrIna7naSviSrSt/z8/IS+V2UsHQ5HQt+v2nPH7XYn6q2qPod6+Y5MZM4JewNVomMRV0Czs7MpPT096MFbtWpVysnJCVJAR40a5W+2zJTWq1ePcnNz/WnhPohk2eFu68mWJ18GiS6JrJxpY5cM92pBQYHW3YR9TYZ7VRQ0TUlL2IHkjskPpkQXPTx3oIAm9l0WcQXUZDJRyZtIZgNsNlsQ2XXr1vnPv/32W/J6vVS/fn1/WrgODh8+rNpTq1atcBWpu3KE7/HjxykzM1N3bQtXg6R/R48eVT9UEnkGVH6o1ahRI1zYdFeO3Kuy4lG9evVSzwTdNfYUGiTPHfnhbUzgcIoy2SDP9UR/7sjzJjU19RTuBn1feuTIEfUjonbt2jFvKLbpxXwIItqAiBsh1axZUy09FRYW+jsiX6oNGjTwn+MABEAABEAABEAABEAgeQhEXAE1m83UuXNnmjlzpqK6YMECNdshMx4QEAABEAABEAABEACB5CMQ8SV4Qfroo4/63S/JEtTLL7+cfKTRYxAAARAAARAAARAAAUXAwHstvdFiIXtLqlWrdsLqZA/oe++9p/b3nTBzJTPIBnnpciLvLZH+yb5bmX1OVJH+yViW3EucaP2VPqakpCRat/z9kXtVtufI5zGR90fKOMrnMZH3K8s4yp7/RH/uyM0r/UxU0dN3pASumTdvXqKiTvp+RVUBrQztSOnF4gh/165dNG3atMo0B3l1RmD69Ok0YMAAkiAHVqtVZ61Dc0IlIO7YrrzySpo4cSJdcskloV6GfDokcNVVV9EVV1yhVrt02Dw0KUQCL730EolR8FdffRXiFZHLlsg/2CJHLX5K1u0UWaRuPFFsxcdZpMqPn6GP75Zq4yi9wFjG91hqvkAxjvE/jvK5xDjG9zjKGMoKE8YxvscxHlofcSOkeICANoIACIAACIAACIAACESPgG5nQCOFQJzcN2zYMFLFo9woEWjUqBFdc801Cb1vMEooY1qNREWTcdSDz8GYgkiAymULxVlnnZUAPUnuLrRu3Vr5rE1uCuh9NAjodg9oNDqPOkAABEAABEAABEAABKJPAEvw0WeOGkEABEAABEAABEAgqQkklQIqbkIWLVpEixcvTop4xYl0Z4trkCVLltDq1auVG63Avomrjp9++okOHjwYmIxjHROQONMl3avI+P34448k4wnRP4G1a9eq8ZIwo4GC52wgDf0fS0jjOXPmlPn8xLNV/+MXzy00vcISzx0Ite0FBQXUr18/FRZUlFD58rv66qth6RcqwBjm279/P913331qrORLb/LkyXT99dcrf4NjxoyhGTNmkMPhoLfeeou6du2K/UsxHKtQq37ttdfUZ/Cmm25Sl4g7raefflr5CZbxFf+urVq1CrU45IsygUmTJtE333xD6enpNHr0aGrevLkKr4znbJQH4hSrk+9CCQwj/rnF97Z4pNA+d3i2niJcXH5iAuxyISlkypQpXv5A+fv60EMPeX/77Tf/OQ70S+DNN9/08sPR30D2U+flYAXebdu2eVmB8bLLEPUe+3b1Dhs2zJ8PB/okwLOcXv4x6O3bt6+/gXK8atUqdc4/OLz8A8PLM2n+93GgHwLsu9V76623enkWWzVq+fLl3o8//lgd4zmrn3EKpSX8o887f/58lXXjxo3e22+/XR3j2RoKPeQ5VQJJswS/efNmat++vV8jl2NxtgvRP4H+/fvTPffc42+oLBnJTMvWrVupTZs2fkt4jKkfkW4PsrKy6NNPP1XhebVGulwu2r17txpLSatbty6Jdbw4qYfojwArnHTuuefSgQMH6IcffqAWLVrQ3XffrRqK56z+xquiFjVo0ICWLVtGx48fp6VLl1KdOnVUdjxbK6KG98JFIGkUUFnGzczM9HOT40OHDvnPcaBfAhKmUQtHOXfuXKWsXHvttbRv376g5XaMqX7HUFomy3tDhw5VS+2ydKtJdna2WsoNdHxdtWpVysnJ0bLgVUcERPHcvn07yTYK2RJz7733qv3Z0kQ8Z3U0UCE05YEHHiBeCaSePXvSBx98QP/617/UVXi2hgAPWU6ZQNL4AZXYvRLdQROZdUlNTdVO8RoHBGbOnElTp05Ve84yMjJUPGaMaRwMXFETJfyt+Ils27YtrV+/3t/wkp9NeUM+n7IPFKI/AvJDQn4cSKhGGTtZhfj666+pS5cu+Ezqb7gqbNHjjz9Offr0oRtvvFEpoo8++qh/XPFsrRAd3gwDgaSZAa1Vq1bQjIo8QGX5ARIfBHiPGX3++ec0fvx4aty4sWq0OC8PnCWT4/r168dHh5KwlbNmzVIGYxIz/MknnyTeZ0a9evWimjVrKuNAsZ7WBJ9PjYT+XuVz17JlS6VsSuvOPPNM/3YmPGf1N17ltUi8TsifGAKazWa66KKL1BK8/DjEs7U8akgPJ4GkUUDlwzV79myy2+3qQyeumNq1axdOligrQgREcRE3IRMnTlT7A7VqOnbsSGvWrKFdu3apGTM2TKJOnTppb+NVZwQ++eQT5S5LXGaxYRk1adJEWVLLl1/nzp1JZrhFFixYQNWrV1d/OusCmsMELrjgAjWDLft5ReSzKXtCRfCcVRji4j/5sSAR5TS3Z7J9QlxqnXPOOYRna1wMYdw3MmmW4K+44grlA/TOO+9URit33HGH+gKM+xFMgg68//77JF92PXr08Pf2lltuoaeeeorYmwHJPqYaNWqomVFZToLEHwFZ+nvuuefUUq7RaFSuYeKvF8nRYjFUkfGSP9kKIz8gRo4cqTqP52x83QNPPPEEyfM1Ly9P+VcWV2hWq1X94dkaX2MZj61NulCc4gBb9n7KQxOSGATESb0s38qXISS+CRw5ckT5JIzvXiRH62WPoCguYjBWUvCcLUlE3+f5+fnKELBkK/FsLUkE5+EkkHQKaDjhoSwQAAEQAAEQAAEQAIHKE0iaPaCVR4MrQAAEQAAEQAAEQAAEIkEACmgkqKJMEAABEAABEAABEACBcglAAS0XDd4AARAAARAAARAAARCIBAEooJGgijJBAARAAARAAARAAATKJQAFtFw0eAMEQAAEQAAEQAAEQCASBKCARoIqygQBEAABEAABEAABECiXABTQctHgDRAAARAAARAAARAAgUgQgAIaCaooEwRAoNIEsrOzVWQrCdWpya+//kr9+/cneQ8CAiAAAiCQOASggCbOWKInIBDXBCTEo81mo759+1JOTg4dOnSIJGRulSpVSN6DgAAIgAAIJA4BREJKnLFET0Ag7gnY7Xbq0KEDdezYUYV53LlzJy1atIhSUlLivm/oAAiAAAiAQDEBKKDFLHAEAiCgAwKrVq2izp07q9nQlStXUtOmTXXQKjQBBEAABEAgnASwBB9OmigLBEDglAlkZGSoGU+3203yBwEBEAABEEg8ApgBTbwxRY9AIG4JuFwu6tq1KzVu3Jg8Hg/t3r2bFi5cSGazOW77hIaDAAiAAAiUJoCnemkmSAEBEIgRgcGDB9O2bdvou+++UwroOeecQ5I2aNCgGLUI1YIACIAACESCAGZAI0EVZYIACFSawJIlS6hbt240bdo0uu2229T1n376qbKKF3dMF1xwQaXLxAUgAAIgAAL6JAAFVJ/jglaBAAiAAAiAAAiAQMISgBFSwg4tOgYCIAACIAACIAAC+iQABVSf44JWgQAIgAAIgAAIgEDCEoACmrBDi46BAAiAAAiAAAiAgD4JQAHV57igVSAAAiAAAiAAAiCQsASggCbs0KJjIAACIAACIAACIKBPAlBA9TkuaBUIgAAIgAAIgAAIJCwBKKAJO7ToGAiAAAiAAAiAAAjokwAUUH2OC1oFAiAAAiAAAiAAAglLAApowg4tOgYCIAACIAACIAAC+iTw/wHt6aBscvmaigAAAABJRU5ErkJggg==" /><!-- --></p>
+<p>Yikes! That doesn’t look so good. We are definitely not following the curve near x = 0.</p>
+<p>It looks like what is happening is that <code>breakaway</code> is putting too much value on high frequency counts. This isn’t good, since we want to be prioritising the low-frequency counts. The way to do that is with the <code>cutoff</code> parameter. <code>cutoff</code> specifies the maximum number of frequency counts to use in fitting.</p>
+<p>Based on the above plot, I’m going to make the subjective decision to only use the first 10 frequency counts for estimation. The pattern in the frequency counts appears to level off significantly after 10 counts, and furthermore, species level genome bins observed more than 10 times are likely to be uninformative for the structure of rare species.</p>
+<p>To use only the first 10 frequency counts, we run</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb15-1" data-line-number="1">estimated_richness_<span class="dv">10</span> &lt;-<span class="st"> </span><span class="kw">breakaway</span>(ft, <span class="dt">cutoff =</span> <span class="dv">10</span>)</a>
+<a class="sourceLine" id="cb15-2" data-line-number="2">estimated_richness_<span class="dv">10</span></a></code></pre></div>
+<pre><code>## Estimate of richness from method breakaway:
+##   Estimate is 28290
+##  with standard error 7561.18
+##   Confidence interval: (5028, 5580454)
+##   Cutoff:  10
+</code></pre>
+<p>Wow! That changed our original estimate of 7724 significantly – now we think there are 28290 species level genome bins! What’s happening?</p>
+<p>Essentially the structure of this data indicates that there are a huge number of unobserved species. If you follow the curve of the frequency ratios (the plot above), it looks like the y-intercept is going to be close to (y=0). <code>breakaway</code>’s estimate predicts that the number of unobserved species is</p>
+<p>[ \text{number of species observed once} \div \text{the fitted intercept on the frequency ratio plot}. ]</p>
+<p>Therefore, as that intercept gets close to zero, the estimate of the number of unobserved species gets really large! Intuitively, this makes sense – if there are so many rare species, we cannot reliably predict how many unobserved species there are. There is some minimal amount of information needed to estimate total species richness!</p>
+<p><em>Note: Last time we checked (September 2021), <code>breakaway</code>, with the default settings, produced an estimate of 7724. If this number has changed significantly since then, it’s because we are constantly making improvements to the code base, which may change estimates – usually by a little but sometimes by more. Please let me know or <a href="https://github.com/adw96/breakaway/issues">log an issue</a> to let us know if this occured!</em></p>
+<h2 id="conclusions">Conclusions</h2>
+<p>I’m going to wrap up this tutorial by saying that most datasets do not have this many rare species, and species richness estimation is more reliable with fewer rare species. Needless to say, there are a lot of unobserved species level genomes in human host-associated microbiomes, and I look forward to seeing more and more amazing microbes being discovered in the coming years.</p>
+<h2 id="postscript-on-model-selection">Postscript on model selection</h2>
+<p>As mentioned previously, <code>breakaway</code> executes a model selection routine. We see that with the new cut-off, we have a different model:</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb17-1" data-line-number="1">estimated_richness_<span class="dv">10</span> <span class="op">%$%</span><span class="st"> </span>model</a></code></pre></div>
+<pre><code>## [1] &quot;Negative Binomial&quot;
+</code></pre>
+<p>So <code>breakaway</code> ended up choosing the <a href="https://onlinelibrary.wiley.com/doi/abs/10.1111/j.0006-341X.2002.00531.x?sid=nlm%3Apubmed">Chao-Bunge</a> estimator, which is based on a Negative Binomial model. This model is less flexible than the Kemp models discussed previously, but has lower variance in estimation. Essentially if the standard error exceeds the estimate in the Kemp model, <code>breakaway</code> moves on to less complex estimates which have lower variance. Unfortunately the Chao-Bunge doesn’t lend itself to diagnosing model misspecification.</p>
+<p>If you are happy to take on higher variance (e.g., because you have multiple samples and ultimately you will combine them together), you can do so with the following:</p>
+<div class="sourceCode" id="cb19"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb19-1" data-line-number="1">estimated_richness_kemp_<span class="dv">10</span> &lt;-<span class="st"> </span><span class="kw">kemp</span>(ft, <span class="dt">cutoff =</span> <span class="dv">10</span>)</a>
+<a class="sourceLine" id="cb19-2" data-line-number="2">estimated_richness_kemp_<span class="dv">10</span></a></code></pre></div>
+<pre><code>## Estimate of richness from method kemp:
+##   Estimate is 30741
+##  with standard error 38552.78
+##   Confidence interval: (4969, 16986096)
+</code></pre>
+<p>Kemp estimates always allow you to check for model misspecification:</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb21-1" data-line-number="1">estimated_richness_kemp_<span class="dv">10</span> <span class="op">%$%</span><span class="st"> </span>plot</a></code></pre></div>
+<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAqAAAAHgCAYAAAB6jN80AAAEGWlDQ1BrQ0dDb2xvclNwYWNlR2VuZXJpY1JHQgAAOI2NVV1oHFUUPrtzZyMkzlNsNIV0qD8NJQ2TVjShtLp/3d02bpZJNtoi6GT27s6Yyc44M7v9oU9FUHwx6psUxL+3gCAo9Q/bPrQvlQol2tQgKD60+INQ6Ium65k7M5lpurHeZe58853vnnvuuWfvBei5qliWkRQBFpquLRcy4nOHj4g9K5CEh6AXBqFXUR0rXalMAjZPC3e1W99Dwntf2dXd/p+tt0YdFSBxH2Kz5qgLiI8B8KdVy3YBevqRHz/qWh72Yui3MUDEL3q44WPXw3M+fo1pZuQs4tOIBVVTaoiXEI/MxfhGDPsxsNZfoE1q66ro5aJim3XdoLFw72H+n23BaIXzbcOnz5mfPoTvYVz7KzUl5+FRxEuqkp9G/Ajia219thzg25abkRE/BpDc3pqvphHvRFys2weqvp+krbWKIX7nhDbzLOItiM8358pTwdirqpPFnMF2xLc1WvLyOwTAibpbmvHHcvttU57y5+XqNZrLe3lE/Pq8eUj2fXKfOe3pfOjzhJYtB/yll5SDFcSDiH+hRkH25+L+sdxKEAMZahrlSX8ukqMOWy/jXW2m6M9LDBc31B9LFuv6gVKg/0Szi3KAr1kGq1GMjU/aLbnq6/lRxc4XfJ98hTargX++DbMJBSiYMIe9Ck1YAxFkKEAG3xbYaKmDDgYyFK0UGYpfoWYXG+fAPPI6tJnNwb7ClP7IyF+D+bjOtCpkhz6CFrIa/I6sFtNl8auFXGMTP34sNwI/JhkgEtmDz14ySfaRcTIBInmKPE32kxyyE2Tv+thKbEVePDfW/byMM1Kmm0XdObS7oGD/MypMXFPXrCwOtoYjyyn7BV29/MZfsVzpLDdRtuIZnbpXzvlf+ev8MvYr/Gqk4H/kV/G3csdazLuyTMPsbFhzd1UabQbjFvDRmcWJxR3zcfHkVw9GfpbJmeev9F08WW8uDkaslwX6avlWGU6NRKz0g/SHtCy9J30o/ca9zX3Kfc19zn3BXQKRO8ud477hLnAfc1/G9mrzGlrfexZ5GLdn6ZZrrEohI2wVHhZywjbhUWEy8icMCGNCUdiBlq3r+xafL549HQ5jH+an+1y+LlYBifuxAvRN/lVVVOlwlCkdVm9NOL5BE4wkQ2SMlDZU97hX86EilU/lUmkQUztTE6mx1EEPh7OmdqBtAvv8HdWpbrJS6tJj3n0CWdM6busNzRV3S9KTYhqvNiqWmuroiKgYhshMjmhTh9ptWhsF7970j/SbMrsPE1suR5z7DMC+P/Hs+y7ijrQAlhyAgccjbhjPygfeBTjzhNqy28EdkUh8C+DU9+z2v/oyeH791OncxHOs5y2AtTc7nb/f73TWPkD/qwBnjX8BoJ98VQNcC+8AAAA4ZVhJZk1NACoAAAAIAAGHaQAEAAAAAQAAABoAAAAAAAKgAgAEAAAAAQAAAqCgAwAEAAAAAQAAAeAAAAAAEl/b3AAAQABJREFUeAHt3QecFEXax/Fn2SUtOSgneoCKgoKgqIDnKeqZc8J8psPsvWY9I2YxoZ6eCuacw2GA0xMUIyb0BBMgSJQgOSyb5u1/eT03Mzu7zM5O7l/xWWamp7u66ls9u89UV3UXhbxkJAQQQAABBBBAAAEEMiTQKEP7YTcIIIAAAggggAACCDgBAlAOBAQQQAABBBBAAIGMChCAZpSbnSGAAAIIIIAAAggQgHIMIIAAAggggAACCGRUgAA0o9zsDAEEEEAAAQQQQIAAlGMAAQQQQAABBBBAIKMCBRuALly40E477bSonzPOOMMuvvhiu+OOO2zmzJlR0B9//LFbd+7cuVHLE3mxaNGiRFZLaJ0FCxbYueeea3/84x/t8MMPT2ibZFaKLfM111xjd999dzJZ5eQ2VVVVrj3/+c9/1lm+WO8vv/zSbTd9+vSo7WK99Ga8ZVEbJfgi0bImmN06V2vIsb7OzFO4wowZM1xbvP3223Fzffrpp937DzzwQNz3WWim41+/B6urq+vFkS/HSL0qxcoIIJBbAroOaCGmKVOm6PqmoVatWoU22mij8E/r1q3d8kaNGoXuv//+cNUfffRRt/ybb74JL0vkifcLPtSxY8dEVk1onf322y9UUlIS2nvvvUMXXnhhQtvUd6V4Ze7Vq5fbZ33zytX1y8vLXXtefvnldRYx1vuFF15w233yySduO+Wz1157ha6//vpwPvGWhd9M4kmiZU0i67ibJHusx80sjQs//fRT1xa33nprjb14QWeoqKgotMMOO4SWLl1a430W/CZw2WWXOcOKiop6keTLMVKvSrEyAgjklEBJboXDqS/N2WefbTfeeGNUxpMnT7ZDDjnE9N4+++xjXbp0iXq/Pi/effdd8/4A1meTOtedMGGCeQGPvf7663Wu15A345X55ZdftsaNGzck27zcNtZ72bJl9vXXX9tmm23m6rNmzRr717/+ZTvttFO4fvGWhd/kSdoF1OOpXr2dd97ZfU5atmyZ9n2yAwQQQACB1AoU7Cn4upi83j4755xzrLKy0j744IO6VjWvd8omTpxoo0ePNp0SjEw6fbt8+XK3SO8tWbIk8u24z+fNm2c6pajAZ9WqVeF1Vq9e7fJXfuutt557Hvl+eEXviZZrf95XGZs0aZL95z//iXzb1q5d65a/8cYb9tVXX5ny9lNtZdYf8dLSUn+18GNt5Q2v4D354YcfTPuSk4KzRFNd5VQec+bMCZtqyIQCQdW7tiT/f//736Y6rivV5q0g3Oslt+LiYtf2/lAN5a19q8yxy9QOftLp9G+//dbGjBmTsrKWlZW5vFauXOnvJvyoLz8qV+Qp1nW5hjf+75PZs2ebhqzEJuUb78vV4sWLbdy4ceb1EkcdW5Hbr1ixwt5//313rCv/2DRr1izXvrHL1/XaDz732GMP95mMF3yuq3yRx5XqOHbsWIu01edL9VM+kcn/3MlaX1TeeeedhOuQ7D4j95/IZ1HHooaRfP755+73W+T2kc8TPU4jt1lXm0auy3MEEEBgnQI51R+bwsL4p+AvvfTSuLned9997tTUyJEj3fvxTjm99dZboW7durn1vIDEPe6+++4h74+n2+aggw5yyzxk9+iNL427Ly30Ap7QySef7E4b+nlpeIC//+eeey4qL+X5zDPPxM3vySefdOv+4x//CG/z97//3a372GOPhdq2beuWa5iB8tEQgTfffNO9X1uZY0/Br6u8ysz7gxySh/bh16lNmzYh1WVdaV3l1PZbbLFF6Mwzzwx5vdXhempfxx57bCjylKKeH3rooa4MfjmuuOIKt01tp+Br8448Be8F1FH71b69sXE1lslK6Ysvvgj17NnTve+XQ0MpfvnlF/e+/kumrF4gFGratGnorLPOCufjP9lzzz1DXm+t/zKUiGvssa5j/LDDDgvnoSf+sIDIz4+W/e1vfwvpuNKPToFrSMvjjz8eta0M/aEuvoOGOvz666/h9Tp16hTafPPNw6/jPYk9Ba/Piva5//77h7ygvMYmiZbPP668sx/httSwl9deey30/PPPh5o0aeKW6/HII48MeV9U3b78Y0afO++LSkjHuo6J/v37h7wAvkZ5Ihcku0/lkchnUet5X9BCv/vd71yZ1D7yVflVxsjPSyLHaewxkkibqgwkBBBAIFEB9aIVZKorANUfr759+7o/Zl7voat/7C/cn3/+2f0R3XHHHUNeD5/7Be71aoXWX3/90HbbbRfyehBCXm9l6PTTT3djNr0JKS4gqw3T63F1f7Q07lR/ULxeutCJJ57o/jhoTKbXaxVSHgo0Tj31VPdcy+IlPwBVYHnvvfeG7rrrrpDXyxRSXfTH5uijjw5NmzbNlUd5d+jQIbTxxhu7rGorc2wAuq7yKjNv4pKru9c77AKCH3/8MeRNngq1aNEi5PWWxCu6W5ZIObWi/mgrMFDQPH78eFfHE044wdXxxRdfDOf/f//3fyGv9zb00ksvuXbyen9Cm2yyiVuvtgC0Nu/IAFSBhzcZyeWjsXRqn3jLVBAFV3Lu06dPSOYKhlTmDTfcMPSnP/2pQWXVxgok1N7K10/ehDkXdN9www1uUaKuscd6ogGo2lvHl4JSfT68XuGQN4zFLVNdlbwe8FDz5s3dFwKto2Pd39/QoUPdOvpP21100UXh1/GeRAagI0aMcJ/X3//+9+6zEm/9RMqn7XRcKTAePHhwSL8nPvzwQ3e86AuhLJ566qnQ/Pnz3Rhs1VfHhJIfgCrw9M5iuGUaM961a9fQrrvuGg5U3Rsx/yW7T2WTyGdx6tSpoXbt2oUU6OsLjz5/OvZVfv34AWiix6nfZqpfom0aU2VeIoAAAnUKFHwAqkBzyJAh7ucvf/lL6OCDDw5tsMEG7peyetf8FPkLV8sUWCoY9Hs7/fWeeOIJt60fAJ133nkuSPLfj/eoQEE9N7E9WApmevToEerdu3d4M+1TAVVdyQ9AIyfGaH3vlGDopJNOqtEbo3pH/hGKV+bIADTR8iqAVlAU2fujYF29SHVNDEm0nPqjraDO72FUHfXHVXXxe+b0h1a2sRO2vCEBbr3aAlDlpRTrHRmA6n3vVKvLJ9I63jK/x1W9UJHpzjvvdNu/9957LihItqz68qN6q5fOT7fddpvrifSP0URdY4/1RAJQ1VmBpSb9RCYFNjoGFIApeae0XTmvvvrqyNXcMaGAsj7JD0D1hU9uCvRkcM8999TIJtHyaUMdV+qhjTyu9JlQ3pFBsnfK2y279tpr3f78APSmm26K2r/OVGhbBbK1pWT3mehnUcG82kdfbCPT9ttv78rmB6CJHKfaPvIYSWWbRpaN5wggEGyBgp+EpMvp+OPYvD9i5vVgugklRx11lJuI5P3hiJu8b/7m9WaZN4M+6n2vh8G91kQV77Rl1Hu1vdCkJ+8ws3333TdqFa8Xxk048k7pufGG3im/qPfX9WKbbbaJWmW33XYz/Wislsbnff/9924sqMa4KWksYbwxc1GZeC8SLa/XK2deQG7du3c371Sz+1EdvZ6l2CyjXtennF6Abt4f1vD23qlbN1nKH7OndpLtLrvsEl5HTzRG0DsNGbUsnS807q5Zs2bOTmNA/eQFzO6p1zvpyp1sWVUfHYte75x5p6Bdnt6pb1dP/xitj6tfvkQfNc5X43v1+fGC6qjNvF7e8DhkL0g076yBeQGojRo1yk3y00Q/fVaSbQ+NZ/S+RJk3zMS80912wQUXuMuUeV8uw+VItHz+BptuumnUcaVjWMm31XONxVaKHdcc+zkeNGiQW09joP/whz+45/H+S2afiX4W9ftIY9v9Mvv714TGzz77zH/pxoeu6zjV5K7IlI42jcyf5wggEEyBgg9AvV7HGrPgE2lqTZzweiZrrOqd5jLvtLB5p7JqvFfbAn8Shv54xyb9wdCEAE0+8nqSYt+u87XXkxv1viaf6FqnCgq93lVTsOb1HrlZ/grEFfwkkhItr4JOTfq5/fbbXbDh9RC5yTunnHKKecMCrLaAuj7llHdsUiDj10WTSJS8nlL36P+nyUTxtvXfT/WjzPQF58EHH6yR9ZZbbukmLzWkrKqzN/zAhg8f7r5gqD0V1HpDA8L7q49reKNanvi+/tv+MaFJbd5pa39x+NEbe+i+4Ci48cZOmzcswLyecPeo5wpidN3OugK0cGYxT/RFR5OP5KsAXEGolnljGc0b7uHWrk/5tIHKGy9FHkfaX7ykz1Vkat++vXvplyHyvcjnyezTz3Ndvzt0bHnDbCJ3557HllX5res4rZGJtyDVbRpvHyxDAIFgCWSuiyjPXL2xZuad/qpRam9smAvuttpqqxrv1bZAeSnFy0+zY/VHor7Bp/KL/QPpnW4279SZDRs2zDTLWL1vupyTNzFGq4eDNveijv/qU171PHqnhd2MYc1SV2+XN87V1DtXW0pVOZW/gjslzRCOTArA/Z7vyOXpeq5eSH0xUW+Teq1if9Rr19CyesMrXG/cq6++at4wDBdge+Njw1VK1lXBrXrHI1Psser3sqonMrZueq2rMSj4VNLVFBR0KlD1xiK7LyNqCwWNySR9ifKPdfV6esMh3JUX9OXST/Upn7ZJtjdW28ZeZcG3iveFVev7KZl9JvpZ1LEV+xnQfmNvlpDIceqXN/Ix1W0amTfPEUAgmAIEoLW0uzd2yvUw6TR2ZFIvn5J/+lun0XVZlsjL4ESur+cKVr2xhq5HKPI9/dHXaUo/r8j3knmuS8fomqYKdvw/yN7YL/voo49cduppVVpXmRMtrwIina5Tb5mCD29GtnmTRdw+vEkR7jHef4mWM962sct02lGn6L0JSFFvKRj26xv1Rj1f+EGDAlo/xVum40VDH1555RV/Nff4yCOPmE69euMZ3SnShpRV+chb12z1xqqaN9ksHPRpZ8m66rJTfk+bX3gN4YhM+hKj4RuxXyx0elp1V++skk6XqydOx7WSNxnMvDHNLvhUgOQPnXBvJvmfjm998fFm/LvefmWTaPmS3GXUZvrCFZn8Y0+BcqpTop9FtYG+CGgoQmTS5dEiUyLHaeT6ep6JNo3dJ68RQKDwBQhAa2ljb5KLebNizZu05E4zezN63WlA9TJ5l/xxp7a1qTcj1gWf3oQQ94s6XnY6feZNknGnIHXKVMGZTh8qb2/yhCnPVCTvsiumcioIVM+HggiNx/THJCpAUlpXmRMtr24Vqms9KiDQGEjtT7c6VW9V5Fi62LolWs7Y7eK9Vq+jhgB4E0HMmyxiOjXtXXLKvElkDerl8velnh8NJVCeOoXszUJ3PXyxy84//3x3WlcW6qHTFxcFSLqtqjcBxZ02TkVZFfQruNMpV28SmF9M95isq4I5jSHUMa921DCCv/71r1FjJPVZuPLKK92xe8ABB7hTsmpvBZ7axpvQ58qw7bbbunGI3qQYe/bZZ10PqE6be5P2zJuoFB6DrJ7bY445Jqr8ib7QFwAFwt7lxtx+vasvuM9qIuVLdB91racbW+iLhT5rOuNwtTfeVe2s8cqpTol+FuWvcawaa6trG+t3jJZpXGpkSuQ4jVxfzxNt09jteI0AAgjUKeD1XhVkqusyTPEq7P0hcbNFddkRP3k9Cm7Wrwfo3vPGa7rZ8ZGXwvnpp59CXs+Ue1/Xq6wtaca794cr5PUiuXV1GRivNyLk9VpFbRI7Kzvqzf++8GfB6zqVkcnrxQp5f9TD1yf089IlY1QHzeBXilfmyFnwWifR8np/eMPXTdQ+Onfu7C6HpDxqS4mWUzOHdVmZ2KR66TI+kUmXItIlj1QGzQbW5a40O9sL7iNXq/HcN/LfiJ0Fr+XKwws4Xd5eoOZWjbdMl8LRbHAvAHfr6pqMugKB6huZki2r8vB6EN0xFHnlBD/vRF1jj3VdmkfX1owst2bzewFN+GoD2ofXy+8u+eVfZ1bHsHeHqJAXjPlFcI+6DJZ3StgZqD1kp8+GLtvkJ2/YSb2vA+pv6z96XwjcPrwzCO4yYImWL95x5V9TV58NP+lSayq/f8UFfxb8VVdd5a7OoPe88Z/u6hZat66U7D6VZ6KfRf3O875MuKtyqGwDBgxws/r13J8Fr/wSOU5jj5FE2lR5kxBAAIFEBYq0ovcLilSHgCYIadyXToH6Y9FiV9ekJJ3KXNftLHWqXr10mnyk9dOR1Eun3hmdClWvW20pkTInUl6dhtXdgVSf2IlRte1byxMtZ115xL6nMYcahrCudojdbl2vVVadPvYnnGj9eMu03Lu8j7tDjnqkajtetF46y5pI+6sMkUm98br7T7zJLJHr6bnyV69opEfsOhqDrPzkoB7jTKZEylff8mhSlcaxapxvv3793Oe4W7dubkhLffNKZv1EPovKV+Nt9Zlc12cx0eM0sqzZbNPIcvAcAQTyX4AANP/bkBoggEAGBCID0HSM98xAFdgFAgggkDMCjAHNmaagIAgggAACCCCAQDAECECD0c7UEgEEGiigKy5owpE3zrmBObE5AggggACn4DkGEEAAAQQQQAABBDIqQA9oRrnZGQIIIIAAAggggAABKMcAAggggAACCCCAQEYFCEAzys3OEEAAAQQQQAABBAhAOQYQQAABBBBAAAEEMipAAJpRbnaGAAIIIIAAAgggUPttcvLcRncvSkfSjaPqurtNOvZJntkXoN2z3wbZKAHtng317O+Tds9+G6gE+lurO66RClOgIC/DpFsk7rXXXta/f/+Ut5pucafbCnr3wU553rmeoVwzfUvFXDGh3TN7K03aPfsCfN75PZ/to/Dzzz+3d955J9vFYP9pEijYHtA+ffrYzTffnFI23Yt5/vz51rZtW2vevHlK886HzHRf77ru/Z0PdUimjLT7YmvXrl3gev79dm/Tpo2VlpYmc+jk9Tb6vNPutHs2D+KTTz45m7tn32kWYAxomoHJHgEEEEAAAQQQQCBagAA02oNXCCCAAAIIIIAAAmkWIABNMzDZI4AAAggggAACCEQLEIBGe/AKAQQQQAABBBBAIM0CBKBpBiZ7BBBAAAEEEEAAgWgBAtBoD14hgAACCCCAAAIIpFmAADTNwGSPAAIIIIAAAgggEC1AABrtwSsEEEAAAQQQQACBNAsQgKYZmOwRQAABBBBAAAEEogUIQKM9eIUAAggggAACCCCQZgEC0DQDkz0CCCCAAAIIIIBAtAABaLQHrxBAAAEEEEAAAQTSLEAAmmZgskcAAQQQQAABBBCIFiAAjfbgFQIIIFBwAtVLllj1ooUFVy8qhAAC+StQkr9Fp+QIIIAAAusSKHvkIat8d6xbrXibba3Z2f9nRSX86l+XG+8jgEB6BegBTa8vuSOAAAJZE6iY8HE4+FQhqiZ+YRVvjclaedgxAggg4AsQgPoSPCKAAAIFJlA9c2aNGlXPqrmsxkosQAABBNIsQACaZmCyRwABBLIlULxlrxq7Lt6i5rIaK7EAAQQQSLMAAWiagckeAQQQyJZASa/e1uSYP5uVlpo1aWKN9z/QSnbaOVvFYb8FKjBnzbwCrRnVSqcAI9HTqUveCCCAQJYFmuy1t+knFApZUVFRlkvD7gtNYNyCD+yGb++0twY9b42K6NMqtPZNZ304WtKpS94IIIBAjggQfOZIQxRQMSqrK+2qSbfYpOXf2zMzXy6gmlGVTAgQgGZCmX0ggAACCCBQYAKPzHjGpqz8ydXqpu/+bisqVhZYDalOOgUIQNOpS94IIIAAAggUoMDi8qV22w/3hWu2qHyxDf/x/vBrniCwLgEC0HUJ8T4CCCCAQNYFQmvLbO3zz9qaW26y8ldftlBFRdbLFOQC3Pz93basYnkUwYM/PWk/rfw5ahkvEKhNgElItcmwHAEEEEAgZwTK7vm7Vf3na1eeqsmTrHrBfGt26hk5U74gFWRl5SpbW7XWDt/ogBrV/nTxRNukZdcay1mAQKwAAWisCK8RQAABBHJKoHrp0nDw6Res8qMPLXTSECtq3NhfxGOGBFqWtLA7t7k+Q3tjN4UqULABaGVlpa1cmdoB0bqMiVJZWZlVVVUV6jFRa73SYVrrznLoDdr9t89S0GZR++2+du1aq66uzqEjMjNF8T/vOdHuOt3eqNisOuL3btOmtmrNGjOvfVKZgt7u+tumv5250O5B/DubymM51/Mq2AC0UaNG1jjF34z9P0LFxcUpzzvXDxSVLx2m+VBv2v23z1Iu/EHK5PHiByJB/7znRLt7v8urDjzIqr2xn35qdNgRVuwFoalOQW93dbDob2cutHsulCHVxxf5/U+goAPQpin+5eQHIvpwpjrv/zVJ7j5btWpVIOtNu//W7kH7Y+C3e0lJSSCPe//znjPtfshhVuXd2alqxnQr3qyHFW+8cVp+WdLuufN5V6cHqXAFCjYALdwmo2YIIIBAMAWKN/cCT++nENLkZd9btxZdrEWJd5tUEgIBFODrRQAbnSojgAACCGRPQKf5L/r6Gvv7lAezVwj2jECWBQhAs9wA7B4BBBBAIFgCL85+zb5c+o3dP+1Rm7l6TrAqT20R+K8AASiHAgIIIIAAAhkSWFW52q7/9g63t7XV5Xbt5NsytGd2g0BuCRCA5lZ7UBoEEEAAgQIWuGvKAzZ/7cJwDV+f97Z9tOiz8GueIBAUAQLQoLQ09UQAAQQQyKrAz6tm24hpj9UowxWThll1KHjXmq0BwYJACTALPlDNTWURQAABBLIlML9sgf2t5//F3f0v3nudm/8u7nssRKAQBQhAC7FVqRMCCCCAQM4J9O/Qz/RDQgAB7+Y2ICCAAAIIIIAAAgggkEkBAtBMarMvBBBAAAEEEEAAAXpAOQYQQAABBBBAAAEEMitAD2hmvdkbAggggAACCCAQeAEC0MAfAgAggAACCCCAAAKZFSAAzaw3e0MAAQQQaIDAp79+2YCt2RQBBHJFgAA0V1qCciCAAAII1Cnw9dLJNvjjITZ95cw61+NNBBDIfQEC0NxvI0qIAAIIIOAJ6I5Bun/60Mm34IEAAnkuQACa5w1I8RFAAIEgCLwy+037bPFEV9W35r9r7y34KAjVpo4IFKwAAWjBNi0VQwABBApDYHXlGrvu2+FRlblq8s1WWV0ZtYwXCCCQPwIEoPnTVpQUAQQQCKTAP6Y+bHPLfomq+w8rptljM56PWsYLBBDIHwHuBZ8/bUVJEUAAgUAKrN+so13d66IadW9RUlpjGQsQQCA/BAhA86OdKCUCCCAQWIETuh0Z2LpTcQQKVYBT8IXastQLAQQQQAABBBDIUQEC0BxtGIqFAAIIIIAAAggUqgCn4Au1ZakXAggggAACaRQIVVZa5fj3rHrxr1ay3fZW3G3jNO6NrAtNgAC00FqU+iCAAAIIIJBmgVB1tZXddrNVffet21PF66Os2bnnW8nW/dK8Z7IvFAFOwRdKS1IPBBBAAAEEMiRQ9cP34eDT7TIUsvJ/vpKhvbObQhAgAC2EVqQOCCCAAAIIZFLAO/1eI1VW1VjEAgRqEyAArU2G5QggEGiBkNejU7R0iYUqKgLtQOURiCdQvMWW1uj3XaLearzX3lGveYFAXQKMAa1Lh/cQQCCQAtULFljZXbdby9mzLdSsuVWecqo3yaJ/IC2oNALxBIpKSqz5ZVda+eg3LPSrNwmp/wBv/Oc28VZlGQJxBQhA47KwEAEEgiyw9tGHLOQFny6VrbGyEfdbix5bWFGrVnnJMnfNL7a4fKn1btMzL8tPoXNToKi01JoeNjg3C0epcl6AU/A530QUEAEEMi1QNWN69C7L11r1vLnRy/Lo1bXf3m6Xf3NjHpWYoiKAQKELEIAWegtTPwQQqLdA8eYxPYWlLazRhhvVO59c2OCzxRPt1TmjbcLiL91jLpSJMiCAAAIEoBwDCCCAQIxA0xNPskY9t/htabt21uzs/7OiFi1i1sr9l5pIdcU3w8IFvc7rCV1TVRZ+zRMEEEAgWwKMAc2WPPtFAIGcFWjU1gs6L7nM5nvjQFt36GAleRh8CvfZWa/a18smh53neGNB7536iF3Q44zwMp4ggAAC2RCgBzQb6uwTAQTyQ6BxYysqKsqPssaUcmXlKrvxuztjlprdM/Uh06QkEgIIIJBNAXpAs6nPvhFAAIE0CWjW+9W9Loqb+wovOCUhgAAC2RQgAM2mPvtGAAEE0iTQpXRD0w8JAQQQyEUBTsHnYqtQJgQQQAABBBBAoIAFCEALuHGpGgIIIIAAAgggkIsCBKC52CqUCQEEEEAAAQQQKGABAtACblyqhgACCCCAAAII5KIAAWgutgplQgABBBBAAAEECliAALSAG5eqIYAAAggggAACuShAAJqLrUKZEEAAAQQQQACBAhYgAC3gxqVqCCCAAAIIIIBALgoQgOZiq1AmBBBAAAEEEECggAUIQAu4cakaAggggAACCCCQiwIEoLnYKpQJAQQQQAABBBAoYAEC0AJuXKqGAAIIIIAAAgjkogABaC62CmVCAIGcEHjz17FWHarOibJQCAQQQKCQBEoyVZlFixbZF198Yd26dbMePXrU2O28efNsxowZUcuLiops4MCBbtnEiRNt7dq14fc333xza9++ffg1TxBAAIFUCsxaPceumX6bhZqEbMjmx6Uya/JCAAEEAi+QkQBUweNVV11le+65p91777124okn2iGHHBKFP3XqVHv99dfDy+bOnWvLli2zUaNGWWVlpV100UW27bbbht8/7rjjCEDDGjxBAIFUC1z73XArD1XY8Gn32xEbH2StG7dK9S7IDwEEEAisQEYC0DvvvNOuv/5669u3rx1xxBE2ZMgQ22+//axJkyZh+J122sn0o6Sezr/85S92ySWXuNfqGd1oo43s5ptvdq/5DwEEEEinwEeLPrM35r3tdrG4Yqnd9sO9dm3v334fpXO/5I0AAggERSDtAah6L2fPnm19+vRxpp06dbLS0lKbM2eObbzxxnGdH3roIdtqq61sxx13dO9PmTLFBaBjxoxxwekee+zh8ojcWD2lP/30k1vUqFEj12u6YsWKyFUa/DwUCrk81qxZ4/JvcIZ5loHaMtWm+UBAu//W7hoSE4SkMZ+XfX1DVFUfnv60HbbefrZJadeo5YX8wv+8B6Xd/bb0P+9lZWVWVVXlLw7MYy61exD9A3OgeRVNewC6YMECa9GihUX+EmvTpo0tXrw4bgCq0+4vv/yyPfXUU+F2+PHHH+2HH35wPajTp0+3Bx54wB599FHr2LFjeJ0PPvjA9KPUvHlz6969u61evTr8fiqe+L+YysvLraKiIhVZ5lUe1dXVKTfNBwDavdr0pSso6YX5r9n3q6ZGVbcyVGXXfj/c7u15U9TyQn6hz3uQ2t1vSz7vudPuBKD+UVmYj2kPQIuLi2t8i9Q3rGbNmsUVVS9n//79TT2lfjrllFNMP+o5VdIpeq2ncaB+uuWWW/ynpgBRY0Yj8wi/2YAn+oU8f/58UwCtIDdoSV8agjjxi3ZfbO3atYv6ElnIx/4Ojbe3pzrdZyGvJ3TJkqXuC3TTpk2tyPvXfr321rhR40Kufrhu+rwHqd39ivuf99atW4f/5vjvBeExl9o9cpheEOyDVse0B6AdOnSwVatWuaBRv8SVdIB37tw5rvWbb75pZ511VtR7Ol2v3k4/AO3SpYtp1jwJAQQQSLXAtu37uixdIBL67Qun/7sn1fsiPwQQQCCoAmm/DmhJSYkNGDDAzWYX8vjx4923an2zVtIEI421UVLPpl737t3bvfb/0zb333+/e6nT6mPHjrVdd93Vf5tHBBBAAAEEEEAAgTwSSHsAKoszzzzTXnzxRTvmmGNs5MiRdumll4aJzjjjDDe+Uwtmzpxp6623Xrin019p8ODBtnLlSjvppJPcLPp+/fqZfkgIIIAAAggggAAC+SeQ9lPwIunatas999xztnTpUmvbtm2U0ujRo8OvN9tsMxeohhf894nG4txwww1uAozGlPqn8mPX4zUCCCCAAAIIIIBA7gtkJAD1GWKDT395oo+Mw0pUivUQQAABBBBAAIHcFcjIKfjcrT4lQwABBBBAAAEEEMi0AAFopsXZHwIIIIAAAgggEHABAtCAHwBUHwEEEEAAAQQQyLQAAWimxdkfAggggAACCCAQcAEC0IAfAFQfAQQQQAABBBDItAABaKbF2R8CCCCAAAIIIBBwAQLQgB8AVB8BBBBAAAEEEMi0AAFopsXZHwIIIIAAAgggEHABAtCAHwBUHwEEEEAAAQQQyLQAAWimxdkfAggggAACCCAQcAEC0IAfAFQfAQQQQAABBBDItAABaKbF2R8CCCCAAAIIIBBwAQLQgB8AVB8BBBBAAAEEEMi0AAFopsXZHwIBEAiFQgGoJVVEAAEEEEhWgAA0WTm2QwCBuAI/r5ptV0y6Ke57LEQAAQQQQEACBKAcBwggkFKBa769zR6e/oxNWvZ9SvMlMwQQQACBwhEgAC2ctqQmCGRd4INFE+zNef+2kPfvim/oBc16g1AABBBAIEcFCEBztGEoFgL5JlAVqvKCzmHhYn+y+AsbNfdf4dc8QQABBBBAwBcgAPUleEQAgQYJPDHjBft+xZSoPK6dfJuVVa2NWsYLBIIuUD13rq198Xkrf+M1C61eHXQO6h9QAQLQgDY81UYglQIrKlbanVNGWpNGjaN+FqxdZA/89GQqd0VeCOS1QNX06bb6qsus4rV/Wvnzz9rqq6+00NqyvK4ThUcgGYGSZDZiGwQQQCBSoFXjlvbVnmMjF/EcAQTiCFS8+ZpZRUX4ndD8X6zyk4+t8aBdw8t4gkAQBOgBDUIrU0cEEEAAgZwQCFVV1yxHvGU112IJAgUlQABaUM1JZRBAAAEEclmgyZ57mRUVhYtY1K6dlQwYGH7NEwSCIsAp+KC0NPVEAAEEEMi6QHHPLaz5lddYxfvvWlHzUmu81z5W1KJF1stFARDItAABaKbF2R8CCCCAQKAFijfd1PRDQiDIApyCD3LrU3cEEEAAAQQQQCALAgSgWUBnlwgggAACCCCAQJAFCECD3PrUHQEEEEAAAQQQyIIAAWgW0NklAggggAACCCAQZAEC0CC3PnXPKYHQqlUWKi/PqTJRGAQQQAABBNIhwCz4dKiSJwL1EFDQWTbiXqv6/DOzxt6tLAcfaU28S7OQEEAAAQQQKFQBekALtWWpV94IlI969bfgUyX2btFX/vSTVjVtat6Un4IigAACCCBQXwEC0PqKsT4CKRaonjatRo5VP9VcVmOlHF0QWrnCqufOtVB1nFsO5miZKRYCCCCAQGYFOAWfWW/2hkANgUbdu1vVt5Oilhdv0j3qdb68KP/XGCt/7mmzqipr1KWrNTvvQmvUvn2+FJ9yIoAAAghkSIAe0AxBsxsEahNocsBBVrx9/9/e1hjQY/6cl3dJqZ47x8qfedIFn6pM9cyfrfzZp2qrNssRQAABBAIsQA9ogBufqueGQFGTJtb87HMstHq1m4RU5AWh+ZiqZ882C4Wiil49e1bUa14ggAACCCAgAXpAOQ4QyBGBotJSy9fgU4QaSmBeMB2ZirfsHfmS5wgggAACCDgBAlAOBAQQSIlAo/YdrJnXk1vUoaNZcbGV7PAHa3L4ESnJm0wQQAABBApLgFPwhdWe1AaBrAqU9N3aSobfldUysHMEEEAAgdwXoAc099uIEiKAAAIIIIAAAgUlQABaUM1JZRBAAAEEEEAAgdwXIADN/TaihAgggAACCCCAQEEJEIAWVHNSGQQQQAABBBBAIPcFCEBzv40oIQIIIIAAAgggUFACBKAF1ZxUBgEEEEAAAQQQyH0BAtDcbyNKiAACCCCAAAIIFJQAAWhBNSeVQQABBBBAAAEEcl+AADT324gSIoAAAggggAACBSVAAFpQzUll8lngg0UTbGn5snyuAmVHAAEEEEAgIYGCvRVneXm5LV68OCGERFcKhUJu1ZUrV9qaNWsS3axg1quoqEi5aT7gZKLdK6or7YIvh9pO7QbYZZuek1MsfrsXFRXlVLnSXRi/3VetWmVlZWXp3l3O5U+70+7ZPigrKyuzXQT2n0aBgg1AmzRpYu3bt08pXXV1tc2fP99atmxpzZs3T2ne+ZCZAvpUm+ZDvTPR7vdNfdR+Lptts3+ZZ6f2PN42b7VpztCo3du1a2dBC0D9dm/RooWVlpbmTHtkqiC0O+2eqWOttv2UlBRsiFJblQO1nFPwgWpuKpuLAgvX/mrDf7zfFa0qVGVXTro5F4tJmRBAAAEEEEiZAAFoyijJCIHkBG767u+2onJleOP3Fn5kb/3ybvg1TxBAAAEEECg0AQLQQmtR6pNXAt8s+86emflyjTIPnXyLlVdX1FjOAgQQQAABBApBgAEWhdCK1CFvBYqsyEZud3vc8i+rWG7rNe0Q9z0WIoAAAgggkM8CBKD53HqUPe8FerfpafohIYAAAgggECQBTsEHqbWpKwIIIIAAAgggkAMCBKA50AgUAQEEEEAAAQQQCJIAAWiQWpu6IoAAAggggAACOSBAAJoDjUAREEAAAQQQQACBIAkQgAaptakrAggggAACCCCQAwIEoDnQCBQBAQQQQAABBBAIkgABaJBam7oigAACCCCAAAI5IEAAmgONQBEQQAABBBBAAIEgCRCABqm1qSsCCCCAAAIIIJADAgSgOdAIFAEBBBBAAAEEEAiSAAFokFqbuiKAAAIIIIAAAjkgQACaA41AERBAAAEEEEAAgSAJEIAGqbWpKwIIIIAAAgg4gfLycisrK0MjSwIEoFmCZ7cIIIAAAgggkB2BJUuWWJ8+fWzmzJnZKQB7NQJQDgIEEEAAAQQQCJTA0qVL7YcffghUnXOtsgSgudYilAcBBBBAAAEE0iawatUqu/TSS13+V1xxhY0ZM8bOOussGz9+fNQ+X375Zbv11lutoqLCTjnlFPvmm2/s7LPPtgMOOMDuvPNOW7lyZdT6X331lVtvzz33tHPPPdfmzp0b9T4vogUIQKM9eIUAAggggAACBSxQUlJiffv2dTXcaqutbMMNN7RffvnFhg8fHlXrq6++2r2uqqqyBx980PbYYw9bs2aNHXjggXbPPffYCSecYKFQyK0zduxY22GHHVxQOnjwYJswYYI7xU8QGkUa9YIANIqDFwgggAACCCBQyAJNmza1o446ylXxyCOPNAWhJ510ko0ePdoWL17slqs389tvv7XjjjsuTLH33nvbQw895Ho5n3/+eVMP6Xvvvefev/DCC22fffaxZ555xr3/8ccfW5cuXezGG28Mb8+TaIGS6Je8QgABBBBAAAEEgiWg4LJ9+/amwPL000+3xx9/3Pbaay/bYIMNwjPlFWD6aZtttrH11lvPvvzyS9fz+fXXX7t1//a3v/mrWHFxsX3++efh1zyJFqAHNNqDVwgggAACCCAQMAGdlv/zn/9sTz75pOmU+9NPP20nnnhilELXrl3Dr4uKiqxt27bulPvy5cuturraWrZsaY0aNQr/6JT9YYcdFt6GJ9EC9IBGe/AKAQQQQAABBApcQAGkkj+GU88VcN52222uF1TXCNVYz8ikcZ4DBw50i3T5pilTpli/fv1cT2jr1q2tc+fOUafc33rrLWvcuHFkFjyPEKAHNAKDpwgggAACCCBQ+AI63a70xRdf2LJly9zzLbfc0vr372/nn3++GyOqsaKRSaflP/30U5s/f75deeWV1r17d9t5553dKmeccYY98cQTNmrUKNeDqhn1Bx10kC1atCgyC55HCNADGoHBUwQQQAABBBAofAH1WGrc57HHHusCzttvv91VWpORNAY09vS73tx+++1tl112cafbe/fubW+88YYpH6WhQ4e60/GHH3646XR+p06d7KKLLjLNiCfFFyAAje/CUgQQQAABBBAoYAHNel+xYoWVlpaGa6kxnJoVr57Q2HTyySe7WfDqMdUEpMjUvHlzd2mmO+64w/WQbrTRRpFv8zyOQL0CUI2V0LgHXZqgTZs2tvXWW0c1XJz8WYQAAggggAACCOSkQKtWrVy5pk+f7uKbYcOG2SWXXFJrWZs0aVIj+IxcWWM+CT4jRWp/ntAYUI2R0OUH1NXcrVs322+//WzHHXd0r9UNfeqpp5oaj4QAAggggAACCOSbwAsvvGC77babDRgwwIYMGRJVfE1YUo+ngk9S6gTqDEB//vlnNz7i+OOPd2MfXn/9dRdorl271l2s9f3337cLLrjAzSLTTDDd2krd2SQEEEAAAQQQQCBfBC6++GLTLTp1+SWdho9Mmoy0YMEC1/EWuZznDROIVo7IS9e00h0CFHxOnjzZrr32Whs0aJDrAVUXc7t27dzFVzVg94EHHrDvv//e9C0h9ptDRJY8RQABBBBAAAEEclKgWbNmOVmuQi1UrWNA9Q3go48+qvFNoDYIzfjSLad0AVcSAggggAACCCCAAAK1CdTaA6oNYruha8tkzZo14bd06ykSAggggAACCCCAAAK1CdQZgEZupFtU/frrr5GL3PMRI0bYmWeeWWM5CxBAAAEEEEAAAQQQiCeQcAD6008/Wd++fe29995z+WhA7gEHHGDnnnuu7bTTTvHyZhkCCCCAAAIIIIAAAjUEEg5Ax40bZ8ccc4ztsccepltO6UKt6hGdOHGi6eKsJAQQQAABBBBAAAEEEhGodRJS7Ma6/tV1111nP/74o91///2m+6g+/PDD1rNnz9hVeY0AAggggAACCCCAQK0CCfeAfvzxx7bNNtvYZ599Zi+99JL96U9/Ml37c/jw4e6+qLXugTcQQAABBBBAAAEEEIgQSDgA3Xfffa1Xr172zTff2KGHHmrPP/+86wm95ppr7K9//WtEljxFAAEEEEAAAQQQQKB2gToD0Dlz5oS3HDlypOlWVTr17iddpP7rr7+2zTbbzF9kmqxEQgABBBBAAAEEEECgNoFaA9BQKGQHH3ywXXHFFTZ//nwbPHhw3Dx0b/hzzjnHXnvtNfvjH/9ot956a9z1WIgAAggggAACCCCAgARqnYSk22p+8skn9uCDD7qxnptvvrkb99mlSxf7/e9/b8uXL3e339QtODU+VOtrPOg+++yDLAIIIIAAAggggAACtQrU2gOqLXRXo9NOO81++OEH23PPPd2tOa+88krbbbfd7KijjnKTkXTv1Msvv9yNDSX4rNWZNxBAAAEEEEAAASewYsUKe+aZZ+zaa6+1UaNGuU69SJqnnnrKtE6uJZ0d15BMPTY01RmA+pm3bNnSLr30UnvzzTft559/diiC+fTTT+2+++4z3SWppKTWzlQ/Gx4RSIvAL2UL0pIvmSKAAAIIBFcgtHq1rX32aVtz+y1W/q8xFqquTgmG5s7oxj4vv/yyqRNPwWb37t3dddX9HVx00UW2aNEi/2XOPFZ7BuqYTEUAWmfUePPNN9uJJ55onTp1Mt3vvXnz5g5BASkJgVwQmLV6rh30wfH27q6vWOvGrXKhSJQBAQQQQCDPBRRgrRl+q1VP+dHVpOo/X1toyWJretQxDapZVVWVnXDCCXbBBRfYWWedFc5LVxbSWeTJkydbhw4d3HKVYcqUKW7yt79MbyxZssRmzZplG2+8sbVq9b+/e1pfE8F13XYNlVSqqKhw8Zse9X6jRo3cNo0bN3bvr1271srKyqxNmzbutYJe3elSwy4jOxa1njogtc9UpTp7QIcOHeoqr51tsMEGtnTp0lTtl3wQSInANZNvtbllv9htP9ybkvzIBAEEEEAAgWrvKkB+8OlrVIwb6z9N+lHXUp83b567o2RkJkcccYRttNFG9v7774cX6+6T6gTcdNNN7ZZbbnHLn376adt2223tqquusi222ML0WklB6cCBA92E8UGDBrlJ5Ao4J0yYYLvuuqu7jrveP++88+zuu+922+g/TTTX/B0lnenu3bu36+HU1Y00/FLp1Vdftc6dO9uQIUNMeacq1dkD6hdEF51XhKyxnk2bNq2xb3UlK6InIZBJgY8WfWavz3vb7fLh6c/Y8d2OsO4tU/ftLJN1YV8IIIAAArkjUNS8WY3CFP33LHCNN+qxQHeT1Ol29UTGpq233trd7EdXIFLS9dcVaOqSmJtssombe6M7UCoYPfzww+2LL75wk8W1rnpQdbMg3alSvawHHnigmyCu9yZNmuR6RtWRqABXQej555/vbiKkcajjx4+3hQsXuqEA6uVUnPfQQw+5vLQvXXLznXfese23394effTRcL7KuyGpzgBU4xJuvPFGd/tNVei7774zv9s2cqeRXcORy3mOQLoEqkPVduWkYeHsK0OVNnTSLfbUwPvCy3iCAAIIIIBAMgKNOnS0xnvuZRVv/eu3zb0r/TQ58qhksoraRtdS1+nseEkdfR07dgy/pSBTacMNN7StttrKBZzqEdXPAw88YAcddJAde+yxbh1dp11J7ynpNPqLL77obhyk4FV5KO28885uwtO3337rAlsFw3pfE4t06l7jO5VWrVrlek+Vn4Zfbrfddm75/vvv76565F408L86A1B1wT722GNuF4qs1Q3bunXrpHapcQWK1rt51w3t0aNH3Dxmzpxpc+fODb+nwNa/yL0a7PPPP3cVVxQeLxAOb8iTghd46ueXbPLy304P+JV9Z8H79s789+1PnXbyF/GIAAIIIIBAUgJNjz3eirfqa9Vz51jxFltacdduSeUTudEf/vAH15mn0/DqkfSTYhz1TkbeWTKyl1TBqeIhnZlWz6iuvf7EE0+4ieC6Q6XSXnvtZTvt9L+/f+3atXM9m5HzdnTJTAWVOnWvmOukk05y2+p0vYLR008/3b32/1NQqvGjmnykKyPpJ7Jc/nrJPNbsA/5vLtqZJh9pDIKC0NGjRycdfE6cONFVUl3PF198sb3yyitxy6prjj7yyCPufa2jWfZKmgAlsHHjxtmTTz7p8hAWKbgC36+YYgd33qfGz5dL/hNcFGqOAAIIIJBSgZI+fa3J3vumJPhUwdQDeuGFF9pxxx3ngkMtU4yjwE9jO/2eRi1XgKlY7KuvvrLy8nIXfB5yyCHutLuGPSpmmj59ugsQjzzySNdjqTw01lM3BdJ403hJ26p3dOzYse5UvtY57LDDXCehJhlpe01+uu2226xnz55upr5iQCVtpzPiqUi19oAqwtWlAv71r3+54FMztjRAdu+993ZR9o477ui6axMpxJ133mnXX3+9u+yABtpqIOt+++1XY3tVWDPvdbH7yPTcc8/ZgAED7Nxzz3WL1UWsgbVCIgVT4IatLgtmxak1AggggEBeC1xzzTV23XXX2S677OICS/Uwqvfy2WefdT2MfuV0ox+dMf71119dsKnlCl7PPvtsUx4aG3rHHXe4M8KKrV566SV3llmn8Xv16mVHH3103PGamiHv31SoRYsWbnfaRuNCNfvdnwGvAFc9puoQVIB7ySWXuO1KS0v9IjbosdYAVLlq1pO6Z/WjKFw9kmPGjHEzpQSj2VBC06UDapuaX1lZabNnz7Y+ffq4gqpXVYUXXOQ2q73rbS1evNh9I9CAWDWMAl6lqVOnugvhuxfef/369TONXyAA9UV4RAABBBBAAIF8EdBNffSj4DLePBp/OKJmt+tSS/4lkdT5p7PKipfatm0bPh2uyygpPtNdKnXaXNcXVdIt0uP1hL711ls1qDQLXtcf1XXedfreT+oAnDFjhtunenBTleoMQCN3oh5RBXz6ufrqq11B3n77bVdhvys3cn3/uQbCKsJWFO0nQQkvMgCdNm2aG5grKA14VW+nAl/1lP7yyy9Rp/81DlVBbWTSrK733nvPLdL2Gieh7VKZ/NP+uhzVsmXLUpl1XuSl+qfaNB8qTruHbP78+fnQVCkto9/u+qzrl3rQkupPu9Pu2Tzuddq50FO84DOyzpGBYOTy2gLBZOfp+Hkr0K3vPv1t6/uYcACqjPULSYNW1fuoIPKAAw5w3bJ17VQDVmPHC6hX1I/O/W11PSt18/oV12BYXW5AAWhsHtrevyi+v71uFepPbvKHD0QOvPXXa8ij6r9y5UpX9iBOglIvdaq63hvSDpnelnZf7T5vkV8iM90G2dgf7U67B/X3vP6+5sLnXX/7SYUrkFAAqtnruljpBx984AIwHZj65ayDQwNUNatLXbeRPZo+maJ7TefXDC//GqLq/dTp/cikXkX1MvgBqMYn6Nu3Tv1rbIK28ZOe+1f595dF3ode35rUjZzqAFRl8QPQ2ADYL0chP8o11ab54EW7/9buufAHKZPHi9/u+r0VxC9e/uedds/kUZf9feVSuxOAZv94SGcJap0Fr53qgqS6xpQuQqpLH73++utuxpWCSQWBumSAJicpGNW4TAWhGjsQmdSdq/EDo0aNcos1vlNBph9oalyBLi+g01w6ja7ZYMpP+9IYU/Vm6rICmoGl9XQ5p48++shdcDVyPzwPnoDuy1vxzttW9vADVvHhB8EDoMYIIIAAAgjkqUCtPaD69q9ZT5pppQvSxyYFkDvssIP70VhNzXK/66673Ax3zVqPTGeeeWb48ksKKHVlfz+dccYZNmzYMDdD/tBDD7VTTz3VdIpd4xg0S0xp9913tw8//NDN6NL2Rx11VNzeVj9PHoMhsHbkfVb58UeuspXvvWvVc2Zb0yMafqHgYOhRSwQQQAABBLInUGsAqkBPPY16TCRpdrvumhQ73lPbdu3a1RSU6jS7Zm1FJv/aUlqma1P9+c9/dqe5IwfSqhdVwah6V3Xq258NFpkPz4MlUO0dS37w6de84q0x1uTwI6wowWPW345HBBBAAAEEEMisQK0BqIqRaPAZWeS6xmzEBp+R2/nPtc/I4NNfrkddioCEgBNo9L+rKoRFIq60EF7GEwQQQAABBBDIOYHEujdzrtgUKOgCjVq3sZJddotiaLL/gfR+RonwAgEEEEAAgdwUqLMHdMSIEQld71KXPzrooINys4aUqmAFmp54shV7d22o9ibLFXtXYyjpt13B1pWKIYAAAgggUEgCdQagH3/8sbsP/HrrrefuC19bxXU3JALQ2nRYni4BXR6m8Y47memHhAACCCCAAAJ5I1BnAPrII4+4a3DqTke65FIiYzjzpuYUFAEEEEAAAQQQQCArAnWOAVUPky6RpEsuXX311VkpIDtFAAEEEEAAAQQQKCyBOgNQVVWXPNIllLbddtvCqjm1QQABBBBAAAEE1iFQFapaxxq8nYxAnafg/Qw39yZ66IeEAAIIIIAAAggERWBZxXI776ur7OHt70xJlXWt9IceeqhGXoqxdtllF3v66adt//33d5ej1J0h/dt+Rz6vsXEtC6ZNm2Y//fST7bHHHrWskd3F6+wBjSzewoULbdddd7UlS5ZELuY5AggggAACCCBQcAK3fn+vvTnv3/bPOWNSUrfy8nI77bTTTJO8J06cGP7Rrc+Vnn32WVu+fLmNHTvWdKdIpYqKCuvdu7d7Xp//Pv30U7v//vvrs0lG102oB9Qvke4B/+6775oASQgggAACCCCAQKEKTFnxkz0y4xlXveu+vd32/N0u1ry4WUqqe/vtt1v79u1r5KXJ37oZz6uvvuoug6lgdNWqVTZjxgxTJ6CuSqRUVlZmU6dOtS5dutS4ec/8+fNNt1PP9VSvHtBcrwzlQwABBBBAAAEEUiFw1eSbzR//OXvNPLtv6qOpyLbOPLbeemv74osvbOTIkTZhwgS744477IYbbnAB5fHHH2+VlZWud7Rbt2527rnnuludP/zww+E8hwwZYv3797fdd9/d7rrrrvDyXHySUA/opptuaur99O/zvs0227jbdDZt2tQ0xoCEAAIIIIAAAggUisDb89+zcQs+jKrO3VMftKO6HGydm/8uankyLzTeU5O8/fTZZ5+Zfyvzjh072oUXXmijR4+2oUOHmsZ/6lS6XivdeOON9tRTT9mf/vQnU2/nzjvvbCeddJK98cYb7pKZU6ZMcXnn+vXZ/2Yx1foAACOpSURBVFd7XyHOo7qKFXz++uuvbuzCdddd564J6mPF2YRFCCCAAAIIIIBA3gmo13P4D/dZ65JWNcp+15QH7OY+V9ZYXt8F99xzj7Vp0ya8WaLxlE7Df/DBB/b444/bE0884bbXvJxPPvnE9ZhqwlGTJk3c8v3228/efvvt8D5y7UlCAejBBx/syj179mz3qBlanTp1yrW6UB4EEEAAAQQQQKBBAsVFxTZ652cblMe6NtakonhjQNe1nd5XgKlT7Y0bN3arn3766da9e3e3XGND/eS/77/OtUfGgOZai1AeBBBAAAEEEAi0QLNmzdypdyH4PZqaAK5JSAMGDDDNmh84cKCbhKTT7xobOmjQIBszZowtXrzYvX7ppZdy2rBeAah6Pb/++mvr0KFDTleKwiGAAAIIIIAAAvkqoMlI48ePN43j1On5P/7xj7bBBhu4MZ/XXHONXX755danTx/bc8897bzzzrPf/e53bizomWee6S7Z1KNHj3APaa4aJHQK3i+8unNV4diUzAVSY/PgNQIIIIAAAgggUMgCurB8KBSqtYqzZs0Kv7do0aLwZS91CczVq1dbaWmpGwKpHtDIyzL5G1122WV2wQUXuB7QFi1a+Itz8jHhHtA///nPbhJSbC1GjBhhirhJCCCAAAIIIIAAAqkRaNSokelUvJ8UfEYm/5qgkcv0XFcoyvXgU+VMOADV7Zz69u1r7733nrazBQsW2AEHHOCuQ7XTTju5ZfyHAAIIIIAAAggggMC6BBIOQMeNG2fHHHOMu6eobg+11VZbuR5R3Urq5JNPXtd+eB8BBBBAAAEEEEAAASeQ8BhQzcLS9T9//PFHd0FUXT5AV9/v2bMnlAgggAACCCCAAAIIJCyQcA/oxx9/bLoDkq7Wr6n9ugJ/v379bPjw4Xlxz9GERVgRAQQQQAABBBBAIK0CCQeg++67r/Xq1cu++eYbO/TQQ+355593PaG6HMBf//rXtBaSzBFAAAEEEEAAAQQKR6DOAHTOnDnhmo4cOdJeeOGFqCv3H3/88e66oJtttll4PU1WIiGAAAIIIIAAAgggUJtArQGorlOlW3BeccUV7sKngwcPjptHt27d7JxzzrHXXnvNXSj11ltvjbseCxFAAAEEEEAAAQQQkECtk5CKiorcze0ffPBBN9Zz8803d+M+u3TpYr///e9t+fLl9v3337sfjQ/V+hoPus8++yCLAAIIIIAAAggggECtArUGoNpCt3867bTT7Nhjj7W7777b3n//fXvggQds5syZ7uKouhTTtttu624JdfTRR1tJSZ3Z1VoI3kAAAQQQQAABBBAIjkBCEWPLli3t0ksvdT+iWblypQtACTiDc6BQUwQQQAABBBBAIFUCtY4B1Q5uvvlmN/5Tz3W/dz8pICX49DV4RAABBBBAAAEEEKiPQJ0B6NChQ23KlCkuvw022MCWLl1an7xZFwEEEEAAAQQQQACBGgJ1noLv3bu3GwOqi86XlZW5sZ66yX1s0j3iTzjhhNjFvEYAAQQQQAABBBD4r4DOJj/xxBNhD8VUG2+8se20005uMnf4jXo+0ZWLNEfnlFNOsQkTJrhhkltvvXWduagszZs3dxPOmzVrZutav87MknizzgD0qaeeshtvvNHdfrOqqsq+++47a9y4cY3ddOjQocYyFiCAAAIIIIAAAvkoMG+x2VPjo0te5L284ODoZfV9tWzZMtexd+qpp1qjRo2svLzcbrjhBttkk03szTffdMvqm6fWr66udvkOGTLEBaBt2rSpM6A899xzbeedd3Y3FlLAuq71kynTurapMwDt0aOHPfbYYy4P3Ybz1VdftdatW68rT95HAAEEEEAAAQTyVmC5N+3lw+9qFr+hAaif4z/+8Y/wXBpN7F5//fXtq6++Ml1dSD2TFRUVpl7Njh07ukfd5KdJkybuMph+Hnpcu3at/fzzz64X1V+uIFSXxvSTOhCnTZtmm266qbu6kfL/9ttvXYCq7WPX13YaftmpU6dwzKcyqgNSAfOsWbNMl+Zs6FygOgNQv/B6nDhxYuRLniOAAAIIIIAAAgg0UECBpi57qQ4+9Ubq5j4LFy50Aeenn37qrq+ugFTzcPr06WOvvPKKCzDVKfiXv/zF3Sa9srIyXIqrrrrKdGb6sssusw8++MAOOeQQF2wqcLzjjjts1apVLthdtGiRde3a1V5//fXw+qNGjXLbrbfeevbll1/asGHD7IwzzrArr7zSpk+fbpMnT7a2bdu6qyGprA3plKxzElK4NjxBAAEEEEAAAQQQSImAbm8+YsQIu/baa2333Xe37bbbzrp37+7ynjRpkukGPz/++KO7BbrOQCsYVK+kAlG9p0fdDn3MmDE2fvx40yn9eEl3sXz88cft7bffdmNPn3nmGTv88MOtf//+7k6Xu+66a3gzBabK85577rFx48bZN998Y1dffbXbl1aaOnWqK9Nnn31mrVq1srfeeiu8bTJPEu4BTSZztkEAAQQQQAABBBCIFlBwpzGgLVq0cKfAjzvuuPAKGg+64YYbutcvvPCCezzxxBPd44IFC+zFF180XQ5TE4gUuCrtv//+UafdtUw9nitWrHB3sdTr7bff3gWjeh4vaZ6PJiMNGjTIva07X+pU+7///W/3et999w3vQ6fzlXdDEgFoQ/TYFgEEEEAAAQQKTqBdS7MDto+uVsSwyug3knilu0vWNoZSwWVk2muvvdwseX9Zu3bt3LhQ9YJq8pFO3+tHAW1kUi+llusUv5809nOLLbbwX0Y9du7c2TRe1M9Tb65evdr80/vt27cPr699ReYbfqMeT6JLW48NWRUBBBBAAAEEEChEgfXbmJ28e/TPSX/KfE2PPPJINy5Utz0fOHCg3XrrraZT4Jokrt7K0aNHu0KpV1TBY2TSWM0//OEP9tprr7nFY8eOdWNGNUFJ22oyUmRSANqzZ8/w+hoKoB/tOx2JHtB0qJInAggggAACCCDQQIEjjjjCXnrpJevWrZubEd+rVy87+uij3alwTUZSgHrJJZeYTpeXlpbW2NsVV1zh1rn++utd0HnXXXe5dXQJJk0uig1Cr7vuOjv22GPdpKMlS5aYxowqME1HKvK6UP/XN5uOPWQhT10m4KKLLjIfOlVFULf0/Pnz3Qwwjb0IWlq8eLFFdsEHpf60+2LTKZ/Iy3oEoe39dtf18eL9Yi90A33eafeaf9Bp98wJnHzyyfbwww9nboc5vKfly5e7WfHquYxNifxt/vXXX91M98htdYMhXdop9tS91tEsfM2ET2eiBzSduuSNAAIIIIAAAgg0UKCuyx0l0jEU74ZB8YJZv5jpDj61H8aA+to8IoAAAggggAACCGREgAA0I8zsBAEEEEAAAQQQQMAXIAD1JXhEAAEEEEAAAQQQyIgAAWhGmNkJAggggAACCCCAgC9AAOpL8IgAAggggAACCCCQEQEC0IwwsxMEEEAAAQQQQAABX4AA1JfgEQEEEEAAAQQQQCAjAgSgGWFmJwgggAACCCCAAAK+AAGoL8EjAggggAACCCCAQEYECvZOSFVVVabbTKUy6dZ8ShUVFYG7LaHqnQ5T5ZvryW933eI1aLejVNuo/vosBa3u/l2K9XlP9e+SXD/maffffs/T7tk9Uv3fvdktBXtPl0DBBqD646GAKZXJ/4OkD0Wq805lOdOZVxDr7bd7Oo6pdLZVqvL26x3UADSon3faPZi/53Op3VUWUuEKFGwAWlJSYi1atEhpy+kP0YoVK6xp06bWvHnzlOadD5mtXbs25ab5UG/a/bd2D1oAGtnupaWl+XCoprSM/ueddk8pa85nlkvtXlxcnPNeFDB5AcaAJm/HlggggAACCCCAAAJJCBCAJoHGJggggAACCCCAAALJCxCAJm/HlggggAACCCCAAAJJCBCAJoHGJggggAACCCCAAALJCxCAJm/HlggggAACCCCAAAJJCBCAJoFWCJusqlxtv65dUghVoQ4IIIAAAgggkGcCBKB51mCpKG7V7Fl2x/Nn2Q0vn2ZV06alIkvyQAABBBBAAAEEEhYgAE2YqjBWrJ4/36becomNbP65PVv6rX3594utasb0wqgctUAAAQQQQACBvBAgAM2LZkpdISs+GG839fzZyotDVl1kdn2f2Vbx7rjU7YCcEEAAAQQQQACBdQgQgK4DqNDentBkjo3ZaFm4WhPWW2WjS+kBDYPwBAEEEEAAAQTSLkAAmnbi3NlBdajarmnxXo0C3dDmYyurWltjOQsQQAABBBBAAIF0CBTsveDTgZXveX6/fIr1brel9WrVw0IL5puFQla0/vpW1Lix/WfpZOvfoV++V5HyI4AAAggggEAeCBCA5kEjpaqIW7bpYXdtc0OqsiMfBBBAAAEEEEAgKQFOwSfFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQoQgCYrx3YIIIAAAggggAACSQkQgCbFxkYIIIAAAggggAACyQqUJLthfbdbtGiRffHFF9atWzfr0aNHrZtPnTrVZs2aZQMHDrTmzZuH15s4caKtXbs2/HrzzTe39u3bh1/zBAEEEEAAAQQQQCA/BDLSA6rg8aSTTrIff/zRLr74YnvllVfi6px//vk2YsQI++GHH+zEE0+0Tz/91K1XWVlpF110kdtO2+pnzpw5cfNgIQIIIIAAAggggEBuC2SkB/TOO++066+/3vr27WtHHHGEDRkyxPbbbz9r0qRJWGfSpEm2cOFCe+KJJ9wy9ZI+++yz1r9/f5sxY4ZttNFGdvPNN4fX5wkCCCCAAAIIIIBAfgqkPQBV7+Xs2bOtT58+TqhTp05WWlrqejA33njjsNqWW25pI0eODL9etmyZlZWVuddTpkxxAeiYMWPcafg99tjD5RFe2Xvy8ccf2y+//BJeVFVVZatXrw6/TsWT6upql42GAoRCoVRkmVd5pMM0HwD8tg5yu69ZsyYfmiqlZfTbvby8PKX55ktm+rzT7vnSWqkrZy61u/83N3W1I6dcEkh7ALpgwQJr0aKFFRUVhevdpk0bW7x4sUUGoI0aNQqP+dQ26gnVaXclnbrXaXn1oE6fPt0eeOABe/TRR61jx47hPB977DEbN26ce62xowMGDDAFselI+qUcxF/MskyXaTraKdV50u6pFs2P/Gj3/GinVJeSdk+1aP3zUwcWqXAF0h6AFhcXm75RRSYdVM2aNYtcFH6uAPOSSy5xY0Y1EUnplFNOcT/qOVVST5R6Q4877jj3Wv/ddddd5h+sFRUVdtVVV5l6W1OZ9G1MwwRat24dDpZTmX+u57VkyRJr165drhcz5eWj3ZdY27Zto75Ephw5BzOk3Wn3yImwOXiIpqVI+j2fK5/3yGF6aaksmWZVIO0BaIcOHWzVqlUuaGzatKmrrHo/O3fuXKPi3333nV166aV23nnn2aBBg8Lva8KRejv9ALRLly42b9688Pt6orz9/HXKTD2u6lVNR1K+6co7HeVNVZ7pNE1VGdOZT9DbPfIsRjqdcy3voB73fr1p91w7ItNbnqC3e3p1yT1SID0RWsQeSkpK3OnwUaNGuaXjx493vWh+T5omGGmspy7TpBnyQ4cOjQo+tZG2uf/++932Gtc5duxY23XXXd1r/kMAAQQQQAABBBDIL4G094CK48wzzwxffkm9SDo97qczzjjDhg0bZh9++KEtXbrUzjnnHP8td53PV1991QYPHuxmwOtSTjoFrklI/fr1C6/HEwQQQAABBBBAAIH8EchIANq1a1d77rnnXICpsSWRafTo0e6lJhgpUI2XNObyhhtucLPaNabUP9Ueb12WIYAAAggggAACCOS2QEYCUJ8gNvj0lyf66I8BTXR91kMAAQQQQAABBBDIPYG0jwHNvSpTIgQQQAABBBBAAIFsChCAZlOffSOAAAIIIIAAAgEUIAANYKNTZQQQQAABBBBAIJsCBKDZ1GffCCCAAAIIIIBAAAUIQAPY6FQZAQQQQAABBBDIpgABaDb12TcCCCCAAAIIIBBAAQLQADY6VUYAAQQQQAABBLIpQACaTX32jQACCCCAAAIIBFCAADSAjU6VEUAAAQQQQACBbAoQgGZTn30jgAACCCCAAAIBFCAADWCjU2UEEEAAAQQQQCCbAgSg2dRn3wgggAACCCCAQAAFCEAD2OhUGQEEEEAAAQQQyKYAAWg29dk3AggggAACCCAQQAEC0AA2OlVGAAEEEEAAAQSyKUAAmk199o0AAggggAACCARQgAA0gI1OlRFAAAEEEEAAgWwKEIBmU599I4AAAggggAACARQgAA1go1NlBBBAAAEEEEAgmwIEoNnUZ98IIIAAAggggEAABQhAA9joVBkBBBBAAAEEEMimAAFoNvXZNwIIIIAAAgggEEABAtAANjpVRgABBBBAAAEEsilAAJpNffaNAAIIIIAAAggEUIAANICNTpURQAABBBBAAIFsChCAZlOffSOAAAIIIIAAAgEUIAANYKNTZQQQQAABBBBAIJsCBKDZ1GffCCCAAAIIIIBAAAUIQAPY6FQZAQQQQAABBBDIpgABaDb12TcCCCCAAAIIIBBAAQLQADY6VUYAAQQQQAABBLIpQACaTX32jQACCCCAAAIIBFCAADSAjU6VEUAAAQQQQACBbAoQgGZTn30jgAACCCCAAAIBFCAADWCjU2UEEEAAAQQQQCCbAgSg2dRn3wgggAACCCCAQAAFCEAD2OhUGQEEEEAAAQQQyKYAAWg29dk3AggggAACCCAQQAEC0AA2OlVGAAEEEEAAAQSyKUAAmk199o0AAggggAACCARQgAA0gI1OlRFAAAEEEEAAgWwKEIBmU599I4AAAggggAACARQgAA1go1NlBBBAAAEEEEAgmwIEoNnUZ98IIIAAAggggEAABQhAA9joVBkBBBBAAAEEEMimAAFoNvXZNwIIIIAAAgggEEABAtAANjpVRgABBBBAAAEEsilAAJpNffaNAAIIIIAAAggEUIAANICNTpURQAABBBBAAIFsCpRkc+fp3Hd5ebktXrw4pbsIhUIuv5UrV9qaNWtSmnc+ZFZRUZFy03yoN+3+W7sXFRXlQ3OlrIx+u69atcrKyspSlm++ZOR/3mn3fGmx1JQzl9q9srIyNZUil5wUKNgAtEmTJta+ffuUoldXV9v8+fOtZcuW1rx585TmnQ+ZKaBPtWk+1Jt2X2zt2rWzoAUifru3aNHCSktL8+FQTWkZ9Xmn3Wn3lB5U9cyspKRgQ5R6ShTm6pyCL8x2pVYIIIAAAggggEDOChCA5mzTUDAEEEAAAQQQQKAwBQhAC7NdqRUCCCCAAAIIIJCzAgSgOds0FAwBBBBAAAEEEChMAQLQwmxXaoUAAggggAACCOSsAAFozjYNBUMAAQQQQAABBApTgAC0MNuVWiGAAAIIIIAAAjkrQACas01DwRBAAAEEEEAAgcIUIAAtzHalVggggAACCCCAQM4KEIDmbNNQMAQQQAABBBBAoDAFCEALs12pFQIIIIAAAgggkLMCBKA52zQUDAEEEEAAAQQQKEwBAtDCbFdqhQACCCCAAAII5KwAAWjONg0FQwABBBBAAAEEClOAALQw25VaIYAAAggggAACOStAAJqzTUPBEEAAAQQQQACBwhQgAC3MdqVWCCCAAAIIIIBAzgqU5GzJcqxgS1aaVVebLVvdyEKNzdZUmbVqbta4OMcKSnEQQAABBBBAAIEcFyAATbCBTr3XrLJKHcadwltcf6xZry7hlzxBAAEEEEAAAQQQSECAU/AJILEKAggggAACCCCAQOoECEBTZ0lOCCCAAAIIIIAAAgkIEIAmgMQqCCCAAAIIIIAAAqkTIABNnSU5IYAAAggggAACCCQgwCSkBJC0yn2naxZ8tS1ctNDatG5jzZo1szalCW7MaggggAACCCCAAAJhAQLQMEXdTzq2/u0yTFVrqq1tq5A19y7BREIAAQQQQAABBBCovwCn4OtvxhYIIIAAAggggAACDRAgAG0AHpsigAACCCCAAAII1F+AALT+ZmyBAAIIIIAAAggg0AABAtAG4LEpAggggAACCCCAQP0FCEDrb8YWCCCAAAIIIIAAAg0QIABtAB6bIoAAAggggAACCNRfgAC0/mZsgQACCCCAAAIIINAAAQLQBuCxKQIIIIAAAggggED9BQhA62/GFggggAACCCCAAAINECAAbQAemyKAAAIIIIAAAgjUX4AAtP5mbIEAAggggAACCCDQAAEC0AbgsSkCCCCAAAIIIIBA/QUIQOtvxhYIIIAAAggggAACDRAoacC2Ob3pF198YaeffnpKyxgKhWzt2rXWuHFjKy4uTmne+ZBZRUWFq3s+lDWVZaTdaXc+76n8ROV2Xnzec+fzPn369Nw+WChdgwSKvA9bqEE55OjG6ajWsmXLbIcddrDbbrvN9t133xytOcVKtcCKFStswIABdsstt9j++++f6uzJL0cFVq5caf3797dhw4bZgQcemKOlpFipFli9erVtt912dtNNN9lBBx2U6uzJrx4CRUVF9VibVfNNoGB7QNN14FZXV5uC23Tln28HUFDKS7sHpaX/V099xmn3/3kE6RntHqTWpq7ZEmAMaLbk2S8CCCCAAAIIIBBQAQLQejS8xn7uvffetsEGG9RjK1bNdwG/3Tt37pzvVaH89RAoKSlxn/cNN9ywHluxar4L0O753oKUP18ECnYMaL40AOVEAAEEEEAAAQSCJkAPaNBanPoigAACCCCAAAJZFijYSUgNdV20aJHpUk7dunWzHj161JrdDz/8YD///LP169fPOnbsWOt6vJEfAkuWLHHt3qtXr1qHWsycOdPmzp0brlCHDh1ss802C7/mSX4JaLb7pEmTogo9cODAqNf+Cz7vvkR+P+pyel9++WWNSmy++eamz3Nk4vMeqcFzBFInQAAax3LixIl21VVX2Z577mn33nuvnXjiiXbIIYfUWPOOO+6wyZMnu+DjH//4h919993WpUuXGuuxID8E/vnPf9qLL75oO++8s3vs2bOnnXvuuTUK/+CDD9r8+fOtbdu27r0+ffoQgNZQyp8Fn332md1zzz3WvXv3cKHjBaB83sM8ef+krKzMXn311XA9ysvL7fPPP3e/w2MDUD7vYSaeIJBaAV0HlBQtcPzxx4e++uort/CXX34Jedd+DHnfmKNW8i6QG/KC0lBVVZVb/swzz4RuvPHGqHV4kT8ClZWVocMOOyz0008/uUKvWrUqtN9++4UWL15coxJHHXVUyOv1rrGcBfkpMGLEiNCjjz5aZ+H5vNfJk/dveh0Noeuuuy5uPfi8x2VhIQINFmAMaEw87wUiNnv2bFOvllKnTp2stLTU5syZE7WmF6i4dRo1+o1Qp+C//fbbqHV4kT8CutPNY489ZhtvvLErtHpIdGrW+4IRVQldpNoLSm3hwoX25JNPumMlagVe5J3AlClTrGXLlvb000+bekO936o16sDnvQZJwSzQWaxx48bZeeedV6NOfN5rkLAAgZQJEIDGUC5YsMBatGgRdaH5Nm3auKAjctV58+aZlvupdevW9uuvv/ovecxDAbW7ki5Cfdddd7lL8MSO6502bZq7HasCFQWnOkX/xhtv5GFtKbIvoAD0k08+saZNm9rjjz9uF110kf9W+JHPe5ii4J488sgjNnjwYPd7P7ZyfN5jRXiNQOoEGAMaY6mesNheL/WKNmvWLGrN2PW0TvPmzaPW4UX+CWhywrXXXut6wS6//PIaFdhiiy3slVdesXbt2rn3NG7w4YcfNu90fY11WZAfAmo/jefV2YwDDjjA3X5RZ0E22mijcAX4vIcpCuqJxnL/5z//sauvvjpuvfi8x2VhIQIpEaAHNIZRA9C98X+ul8t/S6dcYy9Cvt5660X1imodLlDvi+Xno063XXjhhdaqVSvzxoNZkyZNalRk6dKlppnyftKkM/0RU68pKf8ENPlEV7Hwh9KozTXsxhv7HVUZPu9RHAXzYsyYMbbbbru5IRjxKsXnPZ4KyxBIjQABaIyj7oIxYMAAGzVqlHtn/PjxrrfL7/GaMWOGaXzg9ttv7y7dMmvWLFPv52uvvWb9+/ePyY2X+SQwdOhQd8mtv/3tb6Yer8jkt/uyZcvcWLE1a9a4XtLXX3/dBg0aFA5gIrfhee4L6C5Xw4cPd6fgVdrvvvvODaXZeuutXeH9dufznvttmUwJ1d5bbbVVjU39dufzXoOGBQikTIA7IcWhVI/IxRdf7IIQ9Yzokky6PpzSPvvsY8OGDbO+ffuagg9deql9+/bWtWtXu/76600BLCn/BPSH6NRTT3UFLyoqCldAl+fRhLTIdtdkpX//+9/ui4fG/qq3dP311w9vw5P8EtD1fkeOHGkVFRVucpm+gOy4446uEpHtzuc9v9o1kdIeffTR7ve7TrVHpsh25/MeKcNzBFInQABah6VOv/jXeqxtNf3R0rhBzaIlBUdAp9w1S14BKKkwBNTbpfaM/AISWzM+77EiwXjN5z0Y7UwtMytAAJpZb/aGAAIIIIAAAggEXoAxoIE/BABAAAEEEEAAAQQyK0AAmllv9oYAAggggAACCARegAA08IcAAAgggAACCCCAQGYFCEAz683eEEAAAQQQQACBwAsQgAb+EAAAAQQQQAABBBDIrAABaGa92RsCCCCAAAIIIBB4AQLQwB8CACCAAAIIIIAAApkVIADNrDd7QwCBBgjobmM33nhjOIfly5fbmWeeabqnNwkBBBBAIH8ECEDzp60oKQKBF9hpp53syiuvtFdeecVZnH322fbuu+/azjvvHHgbABBAAIF8EuDG5fnUWpQVgYALDBo0yC688EI766yz3H3bX3jhBZswYYKVlpYGXIbqI4AAAvklwK0486u9KC0CgRcoLy+3gQMH2sSJE+3ee++1M844I/AmACCAAAL5JsAp+HxrMcqLQMAFSkpKrGXLlk6hoqIi4BpUHwEEEMhPAQLQ/Gw3So1AYAVuueUW+/777+3uu++2Sy65xCZPnhxYCyqOAAII5KsAp+DzteUoNwIBFNBp9wEDBthTTz1lgwcPtkMPPdSmT5/uxoE2adIkgCJUGQEEEMhPAQLQ/Gw3So1A4ATWrFlj2267rfXq1cs0+Uhp/vz5tuWWW9pf/vIXU88oCQEEEEAgPwQIQPOjnSglAggggAACCCBQMAKMAS2YpqQiCCCAAAIIIIBAfggQgOZHO1FKBBBAAAEEEECgYAQIQAumKakIAggggAACCCCQHwIEoPnRTpQSAQQQQAABBBAoGAEC0IJpSiqCAAIIIIAAAgjkhwABaH60E6VEAAEEEEAAAQQKRoAAtGCakooggAACCCCAAAL5IUAAmh/tRCkRQAABBBBAAIGCESAALZimpCIIIIAAAggggEB+CPw/Khy+QQGDgecAAAAASUVORK5CYII=" /><!-- --></p>
+<p>Now this looks pretty good!</p>
+
+</body>
+</html>

--- a/vignettes/intro-diversity-estimation.html.asis
+++ b/vignettes/intro-diversity-estimation.html.asis
@@ -1,0 +1,5 @@
+%\VignetteIndexEntry{intro-diversity-estimation}
+%\VignetteEngine{R.rsp::asis}
+%\VignetteKeyword{intro}
+%\VignetteKeyword{diversity}
+%\VignetteKeyword{estimation}


### PR DESCRIPTION
Adding static html files for the vignettes by adding .asis files and the html files. For future reference - to update the html files, run rmarkdown::render('vignettes/specific-vignette.Rmd'). I chose to add html files instead of pdfs because all the vignettes ware currently set to knit to html files, so static html files are consistent with that. 