### PR TITLE
updating hypothesis testing vignette to not use DivNet

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,11 +2,9 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
     branches:
       - main
-      - master
 
 name: test-coverage
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![R-CMD-check](https://github.com/adw96/breakaway/workflows/R-CMD-check/badge.svg)](https://github.com/adw96/breakaway/actions)
 [![Coverage
-status](https://codecov.io/gh/adw96/breakaway/branch/master/graph/badge.svg)](https://codecov.io/github/adw96/breakaway?branch=master)
+status](https://codecov.io/gh/adw96/breakaway/branch/master/graph/badge.svg)](https://codecov.io/github/adw96/breakaway?branch=main)
 
 Understanding the drivers of microbial diversity is an important
 frontier of microbial ecology, and investigating the diversity of
@@ -20,21 +20,21 @@ richness, as well as the most commonly used estimates.
 `breakaway` authors for estimating Shannon diversity, and other
 diversity indices. `breakaway` focuses on richness while `DivNet`
 focuses on Shannon, Simpson, and other alpha diversities as well as some
-beta diversity indices. Check it out\!
+beta diversity indices. Check it out!
 
 ### Citing breakaway
 
 The `R` package `breakaway` implements a number of different richness
 estimates. Please cite the following if you use them:
 
-  - `breakaway()` and `kemp()`: Willis, A. & Bunge, J. (2015).
+-   `breakaway()` and `kemp()`: Willis, A. & Bunge, J. (2015).
     Estimating diversity via frequency ratios. Biometrics.
-  - `betta()`: Willis, A., Bunge, J., & Whitman, T. (2017). Improved
+-   `betta()`: Willis, A., Bunge, J., & Whitman, T. (2017). Improved
     detection of changes in species richness in high diversity microbial
     communities. JRSS-C.
-  - `breakaway_nof1()`: Willis, A. (2016+). Species richness estimation
+-   `breakaway_nof1()`: Willis, A. (2016+). Species richness estimation
     with high diversity but spurious singletons. arXiv.
-  - `objective_bayes_*()`: Barger, K. & Bunge, J. (2010). Objective
+-   `objective_bayes_*()`: Barger, K. & Bunge, J. (2010). Objective
     Bayesian estimation for the number of species. Bayesian Analysis.
 
 ## Installation
@@ -47,19 +47,19 @@ devtools::install_github("adw96/breakaway")
 ```
 
 `breakaway` is actively maintained and continually expanding and
-developing its scope\! Is there a method you would like to have
+developing its scope! Is there a method you would like to have
 implemented in breakaway? Submit a pull request or contact the
-[maintainer](http://statisticaldiversitylab.com/team/amy-willis)\!
+[maintainer](http://statisticaldiversitylab.com/team/amy-willis)!
 
 ### Documentation
 
-  - The best place to start is the
+-   The best place to start is the
     [vignettes](https://adw96.github.io/breakaway/articles/).
-  - Documentation for functions can be found
+-   Documentation for functions can be found
     [here](https://adw96.github.io/breakaway/reference/index.html)
-  - A pdf of all documentation can be found in the
+-   A pdf of all documentation can be found in the
     [breakaway-manual.pdf](https://github.com/adw96/breakaway/tree/master/breakaway-manual.pdf)
-  - We try to answer frequently asked questions on the
+-   We try to answer frequently asked questions on the
     [wiki](https://github.com/adw96/breakaway/wiki)
 
 ## Humans
@@ -74,7 +74,7 @@ Barger](http://hnrca.tufts.edu/kathryn-barger-ph-d/), [David
 Clausen](https://www.biostat.washington.edu/people/david-clausen) and
 [Sarah Teichman](https://svteichman.github.io/).
 
-Do you have a request for us? Let us know\! We want folks to use
+Do you have a request for us? Let us know! We want folks to use
 `breakaway` and are committed to making it as easy to use as possible.
 
 Do you have a question? Check out the above documentation list, then

--- a/vignettes/diversity-hypothesis-testing.Rmd
+++ b/vignettes/diversity-hypothesis-testing.Rmd
@@ -118,141 +118,71 @@ Under this different model, we see an estimated increase in richness after 82 da
 
 If you choose to use the old way, the structure of `betta_random` is to input your design matrix as `X`, and your random effects as `groups`, where the latter is a categorical variable. Otherwise, the input looks like how you would hand this off to a regular mixed effects model in the package `lme4`!
 
-# Using `betta` with DivNet
+If you are interested in generating confidence intervals for and testing hypotheses about linear combinations of fixed effects estimated in a `betta` or `betta_random` model, we recommend using the `betta_lincom` function.
 
-Note: the rest of the vignette will not run when knit because each code chunk includes the argument `eval=FALSE`. If you are using a Mac or Linux machine, feel free to remove each `eval = FALSE` and re-knit in order to run this code. If you are using a Windows machine this could cause an error. However, you should be able to run the code chunks directly from the script without knitting. 
-
-Maybe you don't care about richness... but you care about Shannon or Simpson diversity! [`DivNet`](https://github.com/adw96/DivNet) is our `R` package for estimating Shannon and Simpson diversity.
-
-```{r, include=FALSE, eval=FALSE}
-remotes::install_github("adw96/DivNet")
-library(DivNet)
-```
-
-DivNet can be slow when you have a large number of taxa (but we are working on it!), so to illustrate we are going to estimate phylum-level Shannon diversity:
-
-```{r, eval=FALSE}
-soil_phylum <- subset_soil %>%
-  tax_glom(taxrank="Phylum")
-```
-
-Easter egg: `phyloseq::tax_glom` can be incredibly slow! [Mike McLaren](https://github.com/mikemc) is a total champ and rewrote it faster -- check out his package [`speedyseq`](https://github.com/mikemc/speedyseq) and `speedyseq::tax_glom` in particular.
-
-Let's treat all samples as independent observations (`X = NULL`) and fit the DivNet model:
-
-(Check out the full documentation for details, including how to run in parallel)
-
-```{r, include=TRUE, cache=TRUE, message=FALSE, results="hide", eval=FALSE}
-dv <- DivNet::divnet(soil_phylum, X = NULL)
-```
-
-This produces an object containing common diversity estimates:
-
-```{r, eval=FALSE}
-dv
-```
-
-We can look at the first few Shannon diversity estimates with the following:
-
-```{r, eval=FALSE}
-combined_shannon <- meta %>%
-  dplyr::left_join(dv$shannon %>% summary,
-            by = "sample_names")
-combined_shannon
-```
-
-You might notice that the estimates are not different from the plug-in estimate (only because we used `X = NULL`), but we have standard errors! That's the real advantage of using DivNet :)
-
-
-```{r, eval=FALSE}
-bt_day_fixed_id_random <- betta_random(formula = estimate ~ Day | ID, 
-               ses = error,  data = combined_shannon)
-bt_day_fixed_id_random$table
-```
-
-and similarly for no random effects.
-
-If you are interested in generating confidence intervals for and testing hypotheses about
-linear combinations of fixed effects estimated in a `betta` or `betta_random` model, we
-recommend using the `betta_lincom` function.
-
-For example, to generate a confidence interval for $\beta_0 + \beta_1$ (i.e., intercept plus
-'Day2' coefficient, or in other words, the mean Shannon diversity in soils on day 82 of the experiment) in the Shannon diversity model we fit in the previous code chunk,
+For example, to generate a confidence interval for $\beta_0 + \beta_1$ (i.e., intercept plus 'Day2' coefficient, or in other words, the mean richness in soils on day 82 of the experiment) using the model we fit in the previous code chunk,
 we run the following code:
 
-```{r, eval=FALSE}
-
+```{r}
 betta_lincom(fitted_betta = bt_day_fixed_id_random,
              linear_com = c(1,1),
              signif_cutoff = 0.05)
-
-
 ```
 
-Here, we've set the `linear_com` argument equal to `c(1,1)` to tell `betta_lincom` to construct
-a confidence interval for $1 \times \beta_0 + 1 \times \beta_1$. Because we set `signif_cutoff` equal to $0.05$, `betta_lincom` returns a $95\%  = (1 - 0.05)*100\%$ confidence interval.
-The p-value reported here
-is for a test of the null hypothesis that $1 \times \beta_0 + 1 \times \beta_1 = 0$ -- 
-unsurprisingly, this is small. (If you are confused about why this is "unsurprising," remember that $\beta_0 + \beta_1$ 
-represents a mean Shannon diversity in soils on day 82 of the experiment of Whitman et al. When can a Shannon diversity be zero?)
+Here, we've set the `linear_com` argument equal to `c(1,1)` to tell `betta_lincom` to construct a confidence interval for $1 \times \beta_0 + 1 \times \beta_1$. Because we set `signif_cutoff` equal to $0.05$, `betta_lincom` returns a $95\%  = (1 - 0.05)*100\%$ confidence interval. The p-value reported here is for a test of the null hypothesis that $1 \times \beta_0 + 1 \times \beta_1 = 0$ -- unsurprisingly, this is small. (If you are confused about why this is "unsurprising," remember that $\beta_0 + \beta_1$ represents a mean richness in soils on day 82 of the experiment of Whitman et al. When can richness be zero?)
 
-The syntax and output using `betta_lincom` with a `betta` object as input is exactly the same 
+The syntax and output using `betta_lincom` with a `betta` object as input is exactly the same
 as with a `betta_random` object, so we haven't included a separate example for this case.
 
 To look at a more complicated example of hypothesis testing, let's now
-include another date of obsercation in the Whitman et al. dataset -- `Day = 1`, 
+include another date of observation in the Whitman et al. dataset -- `Day = 1`, 
 or observations taken on day 12 of this study. We might be interested now
 in determining whether there is _any_ difference across observation times
-in Shannon diversity.
+in richness.
 
 We prepare data and fit a model essentially as we did above. First, 
 we subset the soil data to only biochar-amended plots and allow
 `Day` to equal 0, 1, or 2.
 
-```{r, eval=FALSE}
-
+```{r}
 subset_soil_days_1_2 <- soil_phylo %>%
   subset_samples(Amdmt == 1) %>% # only biochar
-  subset_samples(Day %in% c(0, 1, 2))  # only Days 0 and 82
+  subset_samples(Day %in% c(0, 1, 2))  # Days 0, 12, and 82
 ```
 
 We extract metadata and aggregate to phylum level as above as well:
 
-```{r, eval=FALSE}
+```{r}
 meta_days_1_2 <- subset_soil_days_1_2 %>%
   sample_data %>%
   as_tibble %>%
   mutate("sample_names" = subset_soil_days_1_2 %>% sample_names )
-
-soil_phylum_days_1_2 <- subset_soil_days_1_2 %>%
-  tax_glom(taxrank="Phylum")
 ```
-
 
 We again run DivNet and extract estimates of Shannon diversity.
 
-```{r, eval=FALSE}
-dv_days_1_2 <- DivNet::divnet(soil_phylum_days_1_2, X = NULL)
+```{r}
+richness_days_1_2 <- subset_soil_days_1_2 %>% 
+  breakaway
 
-combined_shannon_days_1_2 <- meta_days_1_2 %>%
-  dplyr::left_join(dv_days_1_2$shannon %>% summary,
+combined_richness_days_1_2 <- meta_days_1_2 %>%
+  dplyr::left_join(summary(richness_days_1_2),
             by = "sample_names")
-combined_shannon_days_1_2
-
+combined_richness_days_1_2
 ```
+
 Now we fit another model with `betta_random`.
-```{r, eval=FALSE}
+
+```{r}
 bt_day_1_2_fixed_id_random <- betta_random(formula = estimate ~ Day | ID, 
-               ses = error,  data = combined_shannon_days_1_2)
+               ses = error,  data = combined_richness_days_1_2)
 bt_day_1_2_fixed_id_random$table
 ```
 
 The output we get from `betta_random` gives us p-values for testing whether
-mean Shannon diversity is the same at day 12 as at day 0 and for whether it is the same at day 82 as at day 0, but we want to get a _single_ p-value for an 
-overall test of whether mean Shannon diversity varies with day at all! To do this, we can use the `test_submodel` function in `breakaway` to test our 
-full model against a null with no terms in `Day` using a parametric bootstrap:
+mean richness is the same at day 12 as at day 0 and for whether it is the same at day 82 as at day 0, but we want to get a _single_ p-value for an overall test of whether mean Shannon diversity varies with day at all! To do this, we can use the `test_submodel` function to test our full model against a null with no terms in `Day` using a parametric bootstrap:
 
-```{r, eval=FALSE}
+```{r}
 set.seed(345)
 submodel_test <- test_submodel(bt_day_1_2_fixed_id_random,
                           submodel_formula = estimate~1,
@@ -260,22 +190,14 @@ submodel_test <- test_submodel(bt_day_1_2_fixed_id_random,
                           nboot = 100)
 
 submodel_test$pval
-
 ```
 
-This returns a p-value of $0$ -- but recall that we obtained
-this p-value with a parametric bootstrap, and we've used only 100 bootstrap 
-iterations. Hence, we'll report $p \leq 0.01$ rather than $p = 0$. In any case,
-we have reasonably strong evidence of some difference in mean Shannon 
-diversity over time, so we reject the null (intercept-only) model. In practice,
-it's a good idea to use more than 100 bootstrap iterations -- 10,000 is a good
-choice for publication. (We use 100 here so the vignette loads in a reasonable amount of time.)
+This returns a p-value of `r submodel_test$pval`, which means that the null hypothesis would not be rejected at a cut-off of $0.05$. This means that we do not have strong enough evidence to reject some difference in mean richness over time. In practice, it's a good idea to use more than 100 bootstrap iterations -- 10,000 is a good choice for publication. (We use 100 here so the vignette loads in a reasonable amount of time.)
 
 And there you have it! That's how to do hypothesis testing for diversity!
-
 
 If you use our tools, please don't forget to cite them!
 
 - `breakaway`: Willis & Bunge. (2015). *Estimating diversity via frequency ratios*. Biometrics. [doi:10.1111/biom.12332](https://doi.org/10.1111/biom.12332).
-- `DivNet`: Willis & Martin. (2018+). *DivNet: Estimating diversity in networked communities*. bioRxiv. [10.1101/305045](https://doi.org/10.1101/305045).
+- `DivNet`: Willis & Martin. (2020). *DivNet: Estimating diversity in networked communities*. Biostatistics. [doi:10.1093/biostatistics/kxaa015](https://doi.org/10.1093/biostatistics/kxaa015).
 - `betta`: Willis, Bunge & Whitman. (2016). *Improved detection of changes in species richness in high diversity microbial communities*. Journal of the Royal Statistical Society: Series C. [doi:10.1111/rssc.12206](https://doi.org/10.1111/rssc.12206).


### PR DESCRIPTION
but to still reference DivNet vignette. This commit removes the use of Divnet (but links the user to the DivNet hypothesis testing tutorial) and changes `betta_lincom` and `test_submodel` to work on richness estimates instead of shannon diversity estimates. 