### PR TITLE
fix incorrect denominator in CIs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: breakaway
 Title: Species Richness Estimation and Modeling
-Version: 4.8.5
+Version: 5.0.0
 Date: 2022-11-17
 Authors@R: c(
     person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     magrittr,
     MASS,
     phyloseq,
+    reformulas,
     stats,
     tibble,
     utils

--- a/R/class_alpha_estimate.R
+++ b/R/class_alpha_estimate.R
@@ -39,7 +39,7 @@ alpha_estimate <- function(estimate = NULL,
   
   # if (is.null(ci) & !is.null(error)) {
   # # TODO need f0
-  #   d <- exp(1.96*sqrt(log(1 + error^2 / f0)))
+  #   d <- exp(1.96*sqrt(log(1 + error^2 / f0^2)))
   #   
   # }
   

--- a/R/model_betta_random.R
+++ b/R/model_betta_random.R
@@ -104,7 +104,7 @@ betta_random <- function(chats = NULL, ses, X = NULL, groups = NULL, formula = N
     # then get 3rd element of that, which is the object after the conditional bar
     group_var <- deparse1((attr(terms(formula), "variables")[[3]])[[3]])
     groups <- data[, group_var]
-    full_form <- lme4::subbars(formula)
+    full_form <- reformulas::subbars(formula)
     sm_form <- update(full_form, paste("~.-",group_var))
     X <- stats::model.matrix(sm_form, data)
     chats <- stats::model.response(stats::model.frame(formula = sm_form, data = data))

--- a/R/plot_alpha_estimates.R
+++ b/R/plot_alpha_estimates.R
@@ -81,18 +81,18 @@ plot.alpha_estimates <- function(x, physeq = NULL, measure = NULL,
   if (is.null(shape) & is.null(color)) {
     my_gg <- ggplot2::ggplot(df)
   } else if (is.null(shape) & !is.null(color)) {
-    aes_map <- ggplot2::aes_string(color = "color")
+    aes_map <- ggplot2::aes(color = .data[["color"]])
     my_gg <- ggplot2::ggplot(df, aes_map)
   } else if (!is.null(shape) & is.null(color)) {
-    aes_map <- ggplot2::aes_string(shape = "shape")
+    aes_map <- ggplot2::aes(shape = .data[["shape"]])
     my_gg <- ggplot2::ggplot(df, aes_map)
   } else if (!is.null(shape) & !is.null(color)) {
-    aes_map <- ggplot2::aes_string(color = "color", shape = "shape")
+    aes_map <- ggplot2::aes(color = .data[["color"]], shape = .data[["shape"]])
     my_gg <- ggplot2::ggplot(df, aes_map)
   }
   
   my_gg <- my_gg +
-    ggplot2::geom_point(ggplot2::aes_string(x = "sample_names", y = "estimate")) + 
+    ggplot2::geom_point(ggplot2::aes(x = .data[["sample_names"]], y = .data[["estimate"]])) + 
     ggplot2::ylab(paste(yname1, "estimate of", yname2)) +
     ggplot2::xlab("") +
     ggplot2::labs(title = title) +
@@ -101,8 +101,10 @@ plot.alpha_estimates <- function(x, physeq = NULL, measure = NULL,
   
   if (!(all(is.na(df$lower)) || all(is.na(df$upper)))) {
     my_gg <- my_gg + 
-      ggplot2::geom_segment(ggplot2::aes_string(x = "sample_names", xend = "sample_names", 
-                                                y = "lower", yend = "upper"))
+      ggplot2::geom_segment(ggplot2::aes(x = .data[["sample_names"]], 
+                                         xend = .data[["sample_names"]],
+                                         y = .data[["lower"]], 
+                                         yend = .data[["upper"]]))
   }
   
   if (!trim_plot) {

--- a/R/plot_betta.R
+++ b/R/plot_betta.R
@@ -41,11 +41,11 @@ betta_pic <- function(y, se,
   
   df <- data.frame("x" = x, "y" = y, "lower" = y - 1.96*se, "upper" = y + 1.96*se)
   
-  ggplot(df, aes_string(x = "x")) +
+  ggplot(df, ggplot2::aes(x = .data[["x"]])) +
     ylab("Alpha-diversity estimate") +
-    geom_point(aes_string(y = "y")) +
-    geom_linerange(aes_string(ymin = "lower", 
-                              ymax = "upper")) +
+    geom_point(ggplot2::aes(y = .data[["y"]])) +
+    geom_linerange(ggplot2::aes(ymin = .data[["lower"]], 
+                              ymax = .data[["upper"]])) +
     theme_bw()
     
 }

--- a/R/richness_breakaway_nof1.R
+++ b/R/richness_breakaway_nof1.R
@@ -306,7 +306,7 @@ breakaway_nof1.default <- function(input_data,
         parameter_table <-  coef(summary(choice$full))[,1:2]
         colnames(parameter_table) <- c("Coef estimates","Coef std errors")
         
-        d <- exp(1.96*sqrt(log(1 + diversity_se^2/f0_pred)))
+        d <- exp(1.96*sqrt(log(1 + diversity_se^2/f0_pred^2)))
         
         yhats <- fitted(choice$full)
         

--- a/R/richness_breakaway_nof1.R
+++ b/R/richness_breakaway_nof1.R
@@ -319,10 +319,11 @@ breakaway_nof1.default <- function(input_data,
                                       "type" = "Prediction"))
         
         my_plot <- ggplot(plot_data, 
-                          aes_string(x = "x", 
-                                     y = "y",
-                                     col = "type", 
-                                     pch = "type")) +
+                          ggplot2::aes(
+                            x = .data$x,
+                            y = .data$y,
+                            col = .data$type,
+                            pch = .data$type)) +
           geom_point() +
           labs(x = "x", y = "f(x+1)/f(x)", title = "Plot of ratios and fitted values: Kemp models (no f1)") +
           theme_bw()

--- a/R/richness_chao1.R
+++ b/R/richness_chao1.R
@@ -45,7 +45,7 @@ chao1 <- function(input_data, output=NULL, answers=NULL) {
     diversity_se <- sqrt(f2*(0.5*(f1/f2)^2 + (f1/f2)^3 + 0.25*(f1/f2)^4))
     
     # TODO: write a function to do this
-    d <- exp(1.96*sqrt(log(1 + diversity_se^2 / f0)))
+    d <- exp(1.96*sqrt(log(1 + diversity_se^2 / f0^2)))
     a_chao <- alpha_estimate(estimate = diversity,
                              error = diversity_se,
                              estimand = "richness",

--- a/R/richness_chao1_bc.R
+++ b/R/richness_chao1_bc.R
@@ -47,7 +47,7 @@ chao1_bc <- function(input_data, output=NULL, answers=NULL) {
     diversity_se <- sqrt(f1*(f1-1)/(2*(f2+1)) + f1*(2*f1-1)^2/(4*(f2+1)^2) + f1^2*f2*(f1-1)^2/(4*(f2+1)^4))
     
     # TODO: write a function to do this
-    d <- exp(1.96*sqrt(log(1 + diversity_se^2 / f0)))
+    d <- exp(1.96*sqrt(log(1 + diversity_se^2 / f0^2)))
     a_chao <- alpha_estimate(estimate = diversity,
                              error = diversity_se,
                              estimand = "richness",

--- a/R/richness_chao_bunge.R
+++ b/R/richness_chao_bunge.R
@@ -117,7 +117,7 @@ chao_bunge <- function(input_data,
     ### quick hack to see what this does: what if f0-hat = 0?
     d <- ifelse(f0 == 0,
                 1,
-                exp(1.96*sqrt(log(1+diversity_se^2/f0))))
+                exp(1.96*sqrt(log(1+diversity_se^2/f0^2))))
     
     ca <- alpha_estimate(estimate = diversity,
                          error = diversity_se,

--- a/R/richness_kemp.R
+++ b/R/richness_kemp.R
@@ -277,7 +277,7 @@ kemp.default <- function(input_data,
         parameter_table <-  coef(summary(choice$full))[,1:2]
         colnames(parameter_table) <- c("Coef estimates","Coef std errors")
         
-        d <- exp(1.96*sqrt(log(1+diversity_se^2/f0)))
+        d <- exp(1.96*sqrt(log(1+diversity_se^2/f0^2)))
         
         yhats <- fitted(choice$full)
         

--- a/R/richness_kemp.R
+++ b/R/richness_kemp.R
@@ -291,10 +291,10 @@ kemp.default <- function(input_data,
                                       "y" = b0_hat, 
                                       "type" = "Prediction"))
         my_plot <- ggplot(plot_data, 
-                          aes_string(x = "x", 
-                                     y = "y",
-                                     col = "type", 
-                                     pch = "type")) +
+                          ggplot2::aes(x = .data[["x"]], 
+                                     y = .data[["y"]],
+                                     col = .data[["type"]], 
+                                     pch = .data[["type"]])) +
           geom_point() +
           labs(x = "x", y = "f(x+1)/f(x)", title = "Plot of ratios and fitted values: Kemp models") +
           theme_bw()

--- a/R/richness_poisson.R
+++ b/R/richness_poisson.R
@@ -77,7 +77,7 @@ poisson_model <- function(input_data,
     ccc_se <- sqrt(ccc_subset/(exp(lambda_hat)-1-lambda_hat))
     
     f0 <- ccc_subset - cc # previously ccc_hat - (cc + cc_excluded)
-    d <- exp(1.96*sqrt(log(1+ccc_se^2/f0)))
+    d <- exp(1.96*sqrt(log(1+ccc_se^2/f0^2)))
   }
   
   

--- a/R/richness_poisson_nof1.R
+++ b/R/richness_poisson_nof1.R
@@ -88,7 +88,7 @@ poisson_model_nof1 <- function(input_data,
     ccc_se <- sqrt(ccc_subset/(exp(lambda_hat)-1-lambda_hat))
     
     f0 <- ccc_subset - cc # previously ccc_hat - (cc + cc_excluded)
-    d <- exp(1.96*sqrt(log(1+ccc_se^2/f0)))
+    d <- exp(1.96*sqrt(log(1+ccc_se^2/f0^2)))
   }
   
   

--- a/R/richness_wlrm_t.R
+++ b/R/richness_wlrm_t.R
@@ -102,7 +102,7 @@ wlrm_transformed <- function(input_data,
         d <- NaN
       } else {
         diversity_se <- sqrt(f0_se^2+n*f0/(n+f0))
-        d <- exp(1.96*sqrt(log(1+diversity_se^2/f0)))
+        d <- exp(1.96*sqrt(log(1+diversity_se^2/f0^2)))
         my_warning <- NULL
       }
       

--- a/R/richness_wlrm_t.R
+++ b/R/richness_wlrm_t.R
@@ -116,7 +116,11 @@ wlrm_transformed <- function(input_data,
                                     "type" = "Prediction"))
       
       my_plot <- ggplot(plot_data, 
-                        aes(x = x, y = y, col = type, pch = type)) +
+                        ggplot2::aes(
+                          x = .data$x,
+                          y = .data$y,
+                          col = .data$type,
+                          pch = .data$type)) +
         geom_point() +
         labs(x = "x", y = "f(x+1)/f(x)", title = "Plot of ratios and fitted values: tWLRLM") +
         theme_bw()

--- a/R/richness_wlrm_ut.R
+++ b/R/richness_wlrm_ut.R
@@ -110,7 +110,7 @@ wlrm_untransformed  <- function(input_data,
           d <- NaN
         } else {
           diversity_se <- sqrt(f0_se^2+n*f0/(n+f0))
-          d <- exp(1.96*sqrt(log(1+diversity_se^2/f0)))
+          d <- exp(1.96*sqrt(log(1+diversity_se^2/f0^2)))
           my_warning <- NULL
         }
         

--- a/R/richness_wlrm_ut.R
+++ b/R/richness_wlrm_ut.R
@@ -124,10 +124,11 @@ wlrm_untransformed  <- function(input_data,
                                       "type" = "Prediction"))
         
         my_plot <- ggplot(plot_data, 
-                          aes_string(x = "x", 
-                                     y = "y",
-                                     col = "type", 
-                                     pch = "type")) +
+                          ggplot2::aes(
+                            x = .data$x,
+                            y = .data$y,
+                            col = .data$type,
+                            pch = .data$type)) +
           geom_point() +
           labs(x = "x", y = "f(x+1)/f(x)", title = "Plot of ratios and fitted values: tWLRLM") +
           theme_bw()


### PR DESCRIPTION
In #207 , @RuggeroCR helpfully pointed out an error in confidence interval construction that has gone unnoticed, as well as a helpful check of alignment with other packages. 

I've confirmed that `f0^2` is the correct denominator and edited it in all appropriate places. 

A better PR would create a new function to do CI construction in one place, but this is what I have time for now. 

We haven't updated the package in a while so also hoping to fix some other out of date components while we're here. 